### PR TITLE
Add coverage and ratio helpers

### DIFF
--- a/algorithms/greedy.py
+++ b/algorithms/greedy.py
@@ -1,7 +1,7 @@
 from typing import Tuple, List
 import numpy as np
 from ..types import ErrorType
-from ..config import Config, coverage_radius, providers_consumers_from_ratio
+from ..config import Config, coverage_radius
 from ..rng import RNGPool
 from ..simulation import euclidean_distance
 from ..qos import reg_err

--- a/config.py
+++ b/config.py
@@ -95,6 +95,20 @@ class Config:
     def num_consumers(self) -> int:
         return self.num_services - self.num_providers
 
+# --- functional helpers -----------------------------------------
+def coverage_radius(cfg: Config) -> float:
+    """Return the coverage radius derived from the configuration."""
+    w, h = cfg.space_size
+    return cfg.coverage_fraction * math.sqrt(w * w + h * h)
+
+
+def providers_consumers_from_ratio(cfg: Config) -> tuple[int, int]:
+    """Compute the provider/consumer counts from ``cfg.ratio_str``."""
+    l, r = _ratio_to_nums(cfg.ratio_str)
+    num_providers = round(cfg.num_services * (l / (l + r)))
+    num_consumers = cfg.num_services - num_providers
+    return num_providers, num_consumers
+
 # one shared instance you import everywhere
 cfg = Config()
 

--- a/data.py
+++ b/data.py
@@ -1,6 +1,6 @@
 import numpy as np, pandas as pd, os
 from typing import List, Tuple
-from .config import Config, providers_consumers_from_ratio
+from .config import Config
 from .rng import RNGPool
 from .simulation import build_trajectories
 from .qos import classify_qos, smooth_qos
@@ -26,7 +26,7 @@ def RecordBuilder(cfg: Config, rng_pool: RNGPool):
       - cost_per_dict: dict[str t] -> list[float] costs of producers
       - transition_matrix: learned Markov T from raw provider QoS
     """
-    num_providers, num_consumers = providers_consumers_from_ratio(cfg)
+    num_providers, num_consumers = cfg.num_providers, cfg.num_consumers
     service_ids = [f"S{i+1}" for i in range(cfg.num_services)]
     providers = service_ids[:num_providers]
     consumers = service_ids[num_providers:]

--- a/experiment.py
+++ b/experiment.py
@@ -1,5 +1,5 @@
 import numpy as np
-from .config import Config, providers_consumers_from_ratio, coverage_radius
+from .config import Config, coverage_radius
 from .rng import RNGPool
 from .data import RecordBuilder
 from .indicators import MetricsRecorder
@@ -10,7 +10,7 @@ from .qos import reg_err
 def run_experiment(cfg: Config) -> dict:
     rng_pool = RNGPool(cfg.master_seed, cfg.num_times)
     records, cost_per_dict, T, providers, consumers = RecordBuilder(cfg, rng_pool)
-    num_providers, num_consumers = providers_consumers_from_ratio(cfg)
+    num_providers, num_consumers = cfg.num_providers, cfg.num_consumers
 
     # normalization bounds (per-time) for errors + cost
     per_time_bounds = {}


### PR DESCRIPTION
## Summary
- add helper functions for coverage radius and provider ratio
- use computed Config properties for provider and consumer counts
- clean up unused imports

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a4f3ea57ec83248f8e8937ee720fa7