### PR TITLE
Add SCS RNG stream and for_time wrapper

### DIFF
--- a/rng.py
+++ b/rng.py
@@ -8,7 +8,7 @@ class RNGPool:
 
     def __post_init__(self):
         root = np.random.SeedSequence(self.master_seed)
-        ss_global, ss_ou, ss_init, ss_greedy, ss_nsga, ss_mopso, ss_mogwo = root.spawn(7)
+        ss_global, ss_ou, ss_init, ss_greedy, ss_nsga, ss_mopso, ss_mogwo, ss_scs = root.spawn(8)
         self.global_ = np.random.Generator(np.random.PCG64(ss_global))
         self.ou = [np.random.Generator(np.random.PCG64(s)) for s in ss_ou.spawn(self.num_times)]
         self.init = np.random.Generator(np.random.PCG64(ss_init))
@@ -16,11 +16,13 @@ class RNGPool:
         self.nsga   = [np.random.Generator(np.random.PCG64(s)) for s in ss_nsga.spawn(self.num_times)]
         self.mopso  = [np.random.Generator(np.random.PCG64(s)) for s in ss_mopso.spawn(self.num_times)]
         self.mogwo  = [np.random.Generator(np.random.PCG64(s)) for s in ss_mogwo.spawn(self.num_times)]
+        self.scs    = [np.random.Generator(np.random.PCG64(s)) for s in ss_scs.spawn(self.num_times)]
         self._ou_node = {}
 
     def for_(self, scope: str, t: int | None=None, idx: int | None=None) -> np.random.Generator:
         if scope == "greedy": return self.greedy[int(t)]
         if scope == "nsga":   return self.nsga[int(t)]
+        if scope == "scs":    return self.scs[int(t)]
         if scope in ("mopso","pso"): return self.mopso[int(t)]
         if scope in ("mogwo","gwo"): return self.mogwo[int(t)]
         if scope in ("init","ou_init"): return self.init
@@ -36,3 +38,7 @@ class RNGPool:
                 )
             return self._ou_node[idx]
         return self.global_
+
+    def for_time(self, scope: str, t: int, idx: int | None = None) -> np.random.Generator:
+        """Backward-compatible wrapper returning a per-time RNG."""
+        return self.for_(scope, t, idx)


### PR DESCRIPTION
## Summary
- extend RNGPool with per-time `scs` RNG streams and `for_time` helper
- route `scope="scs"` calls through dedicated stream

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a4f3d103bc832487b434e7dbaa2ab7