### PR TITLE
Add basic SCS metric helpers

### DIFF
--- a/metrics/__init__.py
+++ b/metrics/__init__.py
@@ -1,3 +1,11 @@
-from .scs import SCSConfig, SCSComponents, scs, expected_scs_next
+"""Metrics public API."""
+
+from .scs import (
+    SCSConfig,
+    SCSComponents,
+    scs,
+    expected_scs_next,
+)
 
 __all__ = ["SCSConfig", "SCSComponents", "scs", "expected_scs_next"]
+


### PR DESCRIPTION
## Summary
- add `SCSConfig` and `SCSComponents` dataclasses
- implement `scs` and `expected_scs_next` helper functions
- expose new metric helpers via `metrics.__init__`

## Testing
- `python - <<'PY'
import sys, py_compile
sys.path = ['/root/.pyenv/versions/3.12.10/lib/python3.12']
py_compile.compile('/workspace/multiobjective/metrics/scs.py')
py_compile.compile('/workspace/multiobjective/metrics/__init__.py')
print('compiled')
PY`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a4f3a891348324ae9f0ef6599369e9