### PR TITLE
Add SCS and blended error metric tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+pythonpath = [".", ".."]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,19 @@
+import numpy as np
+import pytest
+
+from multiobjective.config import Config
+from multiobjective.metrics.scs import SCSConfig
+
+@pytest.fixture
+def rng():
+    return np.random.default_rng(0)
+
+@pytest.fixture
+def scs_config():
+    return SCSConfig(enabled=True, weight=0.5, mc_samples=4)
+
+@pytest.fixture
+def cfg(scs_config):
+    cfg = Config(space_size=(10, 10), coverage_fraction=0.2)
+    cfg.scs = scs_config
+    return cfg

--- a/tests/metrics/test_blended_error.py
+++ b/tests/metrics/test_blended_error.py
@@ -1,0 +1,59 @@
+import pytest
+
+from multiobjective.metrics.scs import blended_error, SCSConfig, OUParams
+
+
+def test_blended_error_returns_base_when_disabled(cfg, rng):
+    cfg.scs = SCSConfig(enabled=False, weight=0.5, mc_samples=1)
+    base = 0.3
+
+    def norm_fn(kind, err, t):
+        return base
+
+    p = {
+        "coords": (0.0, 0.0),
+        "response_time_ms": 1,
+        "throughput_kbps": 1,
+    }
+    c = {
+        "coords": (1.0, 0.0),
+        "response_time_ms": 1,
+        "throughput_kbps": 1,
+    }
+    result = blended_error("rel", p, c, 0, cfg, norm_fn, rng, OUParams(0.0, 0.0, 1.0))
+    assert result == base
+
+
+def test_blended_error_weights_when_enabled(cfg, rng):
+    cfg.scs = SCSConfig(enabled=True, weight=0.5, mc_samples=1)
+    base = 0.2
+
+    def norm_fn(kind, err, t):
+        return base
+
+    p = {
+        "coords": (0.0, 0.0),
+        "qos": "High",
+        "response_time_ms": 1,
+        "throughput_kbps": 1,
+    }
+    c = {
+        "coords": (0.0, 0.0),
+        "response_time_ms": 1,
+        "throughput_kbps": 1,
+    }
+    ou = OUParams(theta=0.0, sigma=0.0, delta_t=1.0)
+    tm = {"High": {"High": 1.0}}
+    result = blended_error(
+        "rel",
+        p,
+        c,
+        0,
+        cfg,
+        norm_fn,
+        rng,
+        ou_params=ou,
+        transition_matrix=tm,
+        mc_rollouts=1,
+    )
+    assert result == pytest.approx((1 - cfg.scs.weight) * base)

--- a/tests/metrics/test_scs.py
+++ b/tests/metrics/test_scs.py
@@ -1,0 +1,80 @@
+import numpy as np
+import pytest
+
+from multiobjective.metrics.scs import (
+    _ou_step,
+    mc_coverage_prob,
+    qos_success_prob,
+    expected_pair_scs_tplus1,
+    OUParams,
+)
+
+
+def test_ou_step_moves_toward_mean(rng):
+    x = np.array([0.0, 0.0])
+    mu = np.array([1.0, 1.0])
+    ou = OUParams(theta=1.0, sigma=0.0, delta_t=1.0)
+    result = _ou_step(x, mu, ou, rng)
+    assert np.allclose(result, mu)
+
+
+def test_mc_coverage_prob_increases_with_radius():
+    kwargs = dict(
+        p_coords=(0.0, 0.0),
+        c_coords=(5.0, 0.0),
+        space_size=(10.0, 10.0),
+        ou=OUParams(theta=0.0, sigma=1.0, delta_t=1.0),
+        K=256,
+    )
+    rng_small = np.random.default_rng(42)
+    rng_large = np.random.default_rng(42)
+    p_small = mc_coverage_prob(radius=1.0, rng=rng_small, **kwargs)
+    p_large = mc_coverage_prob(radius=3.0, rng=rng_large, **kwargs)
+    assert p_small <= p_large
+
+
+def test_qos_success_prob():
+    tm = {"Low": {"Low": 0.1, "Medium": 0.6, "High": 0.3}}
+    prob = qos_success_prob("Low", tm)
+    assert prob == pytest.approx(0.9)
+
+
+def test_expected_pair_scs_matches_product(cfg):
+    p = {
+        "coords": (0.0, 0.0),
+        "qos": "Low",
+        "qos_prob": 0.2,
+        "response_time_ms": 1,
+        "throughput_kbps": 1,
+    }
+    c = {
+        "coords": (5.0, 0.0),
+        "response_time_ms": 1,
+        "throughput_kbps": 1,
+    }
+    tm = {"Low": {"Medium": 0.6, "High": 0.3}}
+    ou = OUParams(theta=0.0, sigma=1.0, delta_t=1.0)
+    radius = 1.0
+    rng_cov = np.random.default_rng(7)
+    rng_pair = np.random.default_rng(7)
+    p_cov = mc_coverage_prob(
+        p_coords=p["coords"],
+        c_coords=c["coords"],
+        space_size=cfg.space_size,
+        radius=radius,
+        ou=ou,
+        rng=rng_cov,
+        K=128,
+    )
+    p_qos = qos_success_prob("Low", tm, fallback_prob=0.2)
+    combined = expected_pair_scs_tplus1(
+        provider_record=p,
+        consumer_record=c,
+        space_size=cfg.space_size,
+        radius=radius,
+        ou=ou,
+        rng=rng_pair,
+        transition_matrix=tm,
+        mc_rollouts=128,
+    )
+    assert combined == pytest.approx(p_qos * p_cov)


### PR DESCRIPTION
## Summary
- add unit tests for OU step, coverage probability, QoS transitions and expected SCS
- test blended_error fallback and weighting logic
- wire pytest discovery via pyproject and provide common fixtures

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a50ee9dc3c83249f8d91b88e0aa50b