### PR TITLE
Validate SCSConfig parameters

### DIFF
--- a/metrics/scs.py
+++ b/metrics/scs.py
@@ -15,6 +15,12 @@ class SCSConfig:
     weight: float = 0.40
     mc_samples: int = 96
 
+    def __post_init__(self) -> None:
+        if not (0.0 <= self.weight <= 1.0):
+            raise ValueError("weight must be between 0.0 and 1.0")
+        if self.mc_samples <= 0:
+            raise ValueError("mc_samples must be positive")
+
 
 @dataclass
 class SCSComponents:

--- a/tests/metrics/test_scs.py
+++ b/tests/metrics/test_scs.py
@@ -7,6 +7,7 @@ from multiobjective.metrics.scs import (
     qos_success_prob,
     expected_pair_scs_tplus1,
     OUParams,
+    SCSConfig,
 )
 
 
@@ -78,3 +79,15 @@ def test_expected_pair_scs_matches_product(cfg):
         mc_rollouts=128,
     )
     assert combined == pytest.approx(p_qos * p_cov)
+
+
+def test_scs_config_weight_bounds():
+    with pytest.raises(ValueError):
+        SCSConfig(weight=-0.1)
+    with pytest.raises(ValueError):
+        SCSConfig(weight=1.1)
+
+
+def test_scs_config_mc_samples_positive():
+    with pytest.raises(ValueError):
+        SCSConfig(mc_samples=0)


### PR DESCRIPTION
## Summary
- ensure SCSConfig enforces valid weight and mc_samples
- test SCSConfig error handling for invalid parameters

## Testing
- `pytest multiobjective/tests -q`


------
https://chatgpt.com/codex/tasks/task_e_68a53392e5388324b3506329ef5a3916