### PR TITLE
Remove unused RNG from SCS metric

### DIFF
--- a/experiment.py
+++ b/experiment.py
@@ -76,8 +76,8 @@ def run_experiment(cfg: Config) -> dict:
             assign.append(min(scores)[1])
 
         scs_rng = rng_pool.for_("scs", t)
-        score_tp, _ = scs(assign, (prods, cons), prev_assign, cfg, scs_cfg, scs_rng)
-        score_res, _ = scs(assign, (prods, cons), prev_assign, cfg, scs_cfg, scs_rng)
+        score_tp, _ = scs(assign, (prods, cons), prev_assign, cfg, scs_cfg)
+        score_res, _ = scs(assign, (prods, cons), prev_assign, cfg, scs_cfg)
         mean_next_tp, _ = expected_scs_next(
             assign, (prods, cons), prev_assign, cfg, scs_cfg, scs_rng, T
         )

--- a/metrics/scs.py
+++ b/metrics/scs.py
@@ -165,7 +165,6 @@ def scs(
     prev_assign: Optional[list[int]],
     cfg: Config,
     scs_cfg: SCSConfig,
-    rng: np.random.Generator,
 ) -> Tuple[float, SCSComponents]:
     prods, cons = pc
     num_c = len(cons)


### PR DESCRIPTION
## Summary
- Drop RNG parameter from `scs` since it was deterministic
- Update experiment runner to call `scs` without RNG

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a5523b13f88324acc39a472ca788ec