### PR TITLE
Ensure deterministic SCS evaluation

### DIFF
--- a/algorithms/base.py
+++ b/algorithms/base.py
@@ -33,18 +33,19 @@ class Individual:
         transition_matrix: dict | None = None,
         ):
         errs, costs = [], []
+        scs_rngs = [rng_pool.for_("scs", t, i) for i in range(len(cons))]
         for i, c in enumerate(cons):
             p = prods[self.genes[i]]
-            # one per-time RNG stream for SCS lookahead
-            scs_rng = rng_pool.for_("scs", t)
 
             errs.append(
                 blended_error(
                     err_type,
-                    p, c, t,
+                    p,
+                    c,
+                    t,
                     cfg,            # access to space, radius, weights, etc.
                     norm_fn,        # existing normalizer
-                    scs_rng,        # RNG for MC
+                    scs_rngs[i],    # RNG for MC
                     ou_params=OU_PARAMS_DEFAULT,
                     transition_matrix=transition_matrix,
                 )

--- a/rng.py
+++ b/rng.py
@@ -25,7 +25,14 @@ class RNGPool:
     def for_(self, scope: str, t: int | None=None, idx: int | None=None) -> np.random.Generator:
         if scope == "greedy": return self.greedy[int(t)]
         if scope == "nsga":   return self.nsga[int(t)]
-        if scope == "scs":    return self.scs[int(t)]
+        if scope == "scs":
+            if idx is not None:
+                return np.random.Generator(
+                    np.random.PCG64(
+                        np.random.SeedSequence([self.master_seed, 3001, int(t), int(idx)])
+                    )
+                )
+            return self.scs[int(t)]
         if scope == "ou":     return self.ou[int(t)]
         if scope in ("mopso","pso"): return self.mopso[int(t)]
         if scope in ("mogwo","gwo"): return self.mogwo[int(t)]

--- a/tests/test_rng_reproducibility.py
+++ b/tests/test_rng_reproducibility.py
@@ -1,0 +1,49 @@
+import pytest
+
+from multiobjective.algorithms.base import Individual
+from multiobjective.rng import RNGPool
+
+
+def norm_fn(kind, err, t):
+    return err
+
+
+def test_individual_evaluation_reproducible(cfg):
+    prods = [
+        {
+            "coords": (0.0, 0.0),
+            "response_time_ms": 1,
+            "throughput_kbps": 1,
+            "cost": 1.0,
+            "qos_prob": 0.5,
+            "qos_volatility": 0.0,
+        }
+    ]
+    cons = [
+        {
+            "coords": (0.0, 0.0),
+            "response_time_ms": 1,
+            "throughput_kbps": 1,
+        }
+    ]
+
+    def run(run_order):
+        pool = RNGPool(master_seed=123, num_times=1)
+        individuals = {"a": Individual([0]), "b": Individual([0])}
+        for key in run_order:
+            individuals[key].evaluate(
+                prods,
+                cons,
+                "rel",
+                norm_fn,
+                0,
+                cfg.gamma_qos,
+                cfg.lambda_vol,
+                cfg,
+                pool,
+            )
+        return individuals["a"].error, individuals["b"].error
+
+    first_run = run(["a", "b"])
+    second_run = run(["b", "a"])
+    assert first_run == pytest.approx(second_run)


### PR DESCRIPTION
## Summary
- Generate deterministic per-consumer RNG streams for SCS calculations
- Use indexed RNGs when blending error metrics
- Add regression test proving algorithm evaluation is reproducible across runs

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a552420d548324846ba30f147312e9