### PR TITLE
Add typed provider/consumer records and update tests

### DIFF
--- a/algorithms/base.py
+++ b/algorithms/base.py
@@ -1,6 +1,6 @@
 from typing import Protocol, List
 import numpy as np, math
-from ..types import ErrorType
+from ..types import ErrorType, ProviderRecord, ConsumerRecord
 from ..config import Config
 from ..rng import RNGPool
 from ..metrics.scs import blended_error
@@ -21,8 +21,8 @@ class Individual:
 
     def evaluate(
         self,
-        prods,
-        cons,
+        prods: List[ProviderRecord],
+        cons: List[ConsumerRecord],
         err_type,
         norm_fn,
         t,
@@ -31,7 +31,7 @@ class Individual:
         cfg: Config,
         rng_pool: RNGPool,
         transition_matrix: dict | None = None,
-        ):
+    ):
         errs, costs = [], []
         for i, c in enumerate(cons):
             p = prods[self.genes[i]]
@@ -50,10 +50,10 @@ class Individual:
                 )
             )
 
-            r = p.get("qos_prob", 0.5)
-            v = p.get("qos_volatility", 0.0)
+            r = p.qos_prob
+            v = p.qos_volatility
             costs.append(
-                ctx_norm_cost(p["cost"], t, norm_fn)
+                ctx_norm_cost(p.cost, t, norm_fn)
                 * (1.0 + lambda_vol * v)
                 / (max(r, 1e-6) ** gamma_qos)
             )

--- a/algorithms/mogwo.py
+++ b/algorithms/mogwo.py
@@ -1,7 +1,7 @@
 import numpy as np
 from ..config import Config
 from ..rng import RNGPool
-from ..types import ErrorType
+from ..types import ErrorType, ProviderRecord, ConsumerRecord
 from ..indicators import MetricsRecorder
 from ..pareto import crowding_distance
 
@@ -43,6 +43,7 @@ def run_mogwo(cfg: Config, rng_pool: RNGPool, records: dict, cost_per: dict,
     for t in range(cfg.num_times):
         rng = rng_pool.for_("gwo", t)
         scs_rng = rng_pool.for_("scs", t)
+        prods: list[ProviderRecord]; cons: list[ConsumerRecord]
         prods, cons = records[t]
         D, P = len(cons), len(prods)
         q = np.zeros((P,D)); c = np.zeros((P,D))
@@ -56,9 +57,12 @@ def run_mogwo(cfg: Config, rng_pool: RNGPool, records: dict, cost_per: dict,
                     ou_params=OU_PARAMS_DEFAULT,
                     transition_matrix=transition_matrix,
                 )
-                r = prods[p].get("qos_prob",0.5); v = prods[p].get("qos_volatility",0.0)
-                base = (prods[p]["cost"] - curr_min) / (curr_max - curr_min + 1e-12)
-                c[p,j] = base * (1.0 + cfg.lambda_vol*v) / (max(r,1e-6)**cfg.gamma_qos)
+                r = prods[p].qos_prob
+                v = prods[p].qos_volatility
+                base = (prods[p].cost - curr_min) / (curr_max - curr_min + 1e-12)
+                c[p, j] = (
+                    base * (1.0 + cfg.lambda_vol * v) / (max(r, 1e-6) ** cfg.gamma_qos)
+                )
 
         wolves = rng.uniform(0, P-1, (cfg.gwo.wolf_size, D)).astype(np.float32)
         archive = []

--- a/metrics/scs.py
+++ b/metrics/scs.py
@@ -6,6 +6,7 @@ import numpy as np
 from ..config import Config, coverage_radius
 from ..qos import reg_err
 from ..simulation import euclidean_distance
+from ..types import ProviderRecord, ConsumerRecord
 
 
 @dataclass
@@ -87,9 +88,9 @@ def qos_success_prob(
     return float(fallback_prob)
 
 def expected_pair_scs_tplus1(
-    provider_record: dict,
-    consumer_record: dict,
-    space_size: Tuple[float,float],
+    provider_record: ProviderRecord,
+    consumer_record: ConsumerRecord,
+    space_size: Tuple[float, float],
     radius: float,
     ou: OUParams,
     rng: np.random.Generator,
@@ -103,14 +104,14 @@ def expected_pair_scs_tplus1(
     Carlo coverage estimate.
     """
     p_qos_next = qos_success_prob(
-        provider_qos_now=provider_record.get("qos"),
+        provider_qos_now=provider_record.qos,
         transition_matrix=transition_matrix,
-        fallback_prob=provider_record.get("qos_prob", 0.5),
+        fallback_prob=provider_record.qos_prob,
     )
 
     p_cov_next = mc_coverage_prob(
-        p_coords=tuple(provider_record["coords"]),
-        c_coords=tuple(consumer_record["coords"]),
+        p_coords=provider_record.coords,
+        c_coords=consumer_record.coords,
         space_size=space_size,
         radius=radius,
         ou=ou,
@@ -121,8 +122,8 @@ def expected_pair_scs_tplus1(
 
 def blended_error(
     err_type: str,
-    p: dict,
-    c: dict,
+    p: ProviderRecord,
+    c: ConsumerRecord,
     t: int,
     cfg: Config,
     norm_fn,                   # your existing norm_err(kind, err, t)
@@ -161,7 +162,7 @@ def blended_error(
 
 def scs(
     assign: list[int],
-    pc: Tuple[list[dict], list[dict]],
+    pc: Tuple[list[ProviderRecord], list[ConsumerRecord]],
     prev_assign: Optional[list[int]],
     cfg: Config,
     scs_cfg: SCSConfig,
@@ -181,7 +182,7 @@ def scs(
 
         cont = float(prev_assign is not None and prev_assign[ci] == pi)
         cov = float(euclidean_distance(p, c) <= radius)
-        qos = float(p.get("qos") in {"Medium", "High"})
+        qos = float(p.qos in {"Medium", "High"})
 
         cont_total += cont
         cov_total += cov
@@ -198,7 +199,7 @@ def scs(
 
 def expected_scs_next(
     assign: list[int],
-    pc: Tuple[list[dict], list[dict]],
+    pc: Tuple[list[ProviderRecord], list[ConsumerRecord]],
     prev_assign: Optional[list[int]],
     cfg: Config,
     scs_cfg: SCSConfig,

--- a/simulation.py
+++ b/simulation.py
@@ -1,6 +1,7 @@
 import numpy as np, math
 from .config import Config
 from .rng import RNGPool
+from .types import ProviderRecord, ConsumerRecord
 
 def OU_step(x_t, mu, theta, sigma, delta_t, rng):
     noise = rng.standard_normal(size=x_t.shape)
@@ -35,9 +36,9 @@ def init_node_positions_and_means(total_nodes, distribution, space, num_clusters
         raise ValueError(f"Unknown distribution {distribution}")
     return np.array(starts), np.array(means)
 
-def euclidean_distance(p: dict, c: dict) -> float:
-    (px,py), (cx,cy) = p["coords"], c["coords"]
-    return math.sqrt((px-cx)**2 + (py-cy)**2)
+def euclidean_distance(p: ProviderRecord, c: ConsumerRecord) -> float:
+    (px, py), (cx, cy) = p.coords, c.coords
+    return math.sqrt((px - cx) ** 2 + (py - cy) ** 2)
 
 def build_trajectories(cfg: Config, rng_pool: RNGPool, num_providers: int, num_consumers: int) -> dict[str, np.ndarray]:
     total = num_providers + num_consumers

--- a/tests/metrics/test_blended_error.py
+++ b/tests/metrics/test_blended_error.py
@@ -1,6 +1,7 @@
 import pytest
 
 from multiobjective.metrics.scs import blended_error, SCSConfig, OUParams
+from multiobjective.types import ProviderRecord, ConsumerRecord
 
 
 def test_blended_error_returns_base_when_disabled(cfg, rng):
@@ -10,16 +11,28 @@ def test_blended_error_returns_base_when_disabled(cfg, rng):
     def norm_fn(kind, err, t):
         return base
 
-    p = {
-        "coords": (0.0, 0.0),
-        "response_time_ms": 1,
-        "throughput_kbps": 1,
-    }
-    c = {
-        "coords": (1.0, 0.0),
-        "response_time_ms": 1,
-        "throughput_kbps": 1,
-    }
+    p = ProviderRecord(
+        service_id="p0",
+        timestamp=0,
+        response_time_ms=1,
+        throughput_kbps=1,
+        cost=0.0,
+        coords=(0.0, 0.0),
+        qos=None,
+        qos_prob=0.0,
+        qos_volatility=0.0,
+    )
+    c = ConsumerRecord(
+        service_id="c0",
+        timestamp=0,
+        response_time_ms=1,
+        throughput_kbps=1,
+        cost=0.0,
+        coords=(1.0, 0.0),
+        qos=None,
+        qos_prob=0.0,
+        qos_volatility=0.0,
+    )
     result = blended_error("rel", p, c, 0, cfg, norm_fn, rng, OUParams(0.0, 0.0, 1.0))
     assert result == base
 
@@ -31,17 +44,28 @@ def test_blended_error_weights_when_enabled(cfg, rng):
     def norm_fn(kind, err, t):
         return base
 
-    p = {
-        "coords": (0.0, 0.0),
-        "qos": "High",
-        "response_time_ms": 1,
-        "throughput_kbps": 1,
-    }
-    c = {
-        "coords": (0.0, 0.0),
-        "response_time_ms": 1,
-        "throughput_kbps": 1,
-    }
+    p = ProviderRecord(
+        service_id="p0",
+        timestamp=0,
+        response_time_ms=1,
+        throughput_kbps=1,
+        cost=0.0,
+        coords=(0.0, 0.0),
+        qos="High",
+        qos_prob=0.0,
+        qos_volatility=0.0,
+    )
+    c = ConsumerRecord(
+        service_id="c0",
+        timestamp=0,
+        response_time_ms=1,
+        throughput_kbps=1,
+        cost=0.0,
+        coords=(0.0, 0.0),
+        qos=None,
+        qos_prob=0.0,
+        qos_volatility=0.0,
+    )
     ou = OUParams(theta=0.0, sigma=0.0, delta_t=1.0)
     tm = {"High": {"High": 1.0}}
     result = blended_error(

--- a/tests/test_records.py
+++ b/tests/test_records.py
@@ -1,0 +1,21 @@
+import pytest
+from multiobjective.types import ProviderRecord, ConsumerRecord
+
+
+def test_provider_record_requires_all_fields():
+    with pytest.raises(TypeError):
+        ProviderRecord(service_id="p0")
+
+
+def test_consumer_record_requires_all_fields():
+    with pytest.raises(TypeError):
+        ConsumerRecord(
+            service_id="c0",
+            timestamp=0,
+            response_time_ms=1.0,
+            throughput_kbps=1.0,
+            cost=0.0,
+            coords=(0.0, 0.0),
+            qos=None,
+            qos_prob=0.5,
+        )

--- a/types.py
+++ b/types.py
@@ -14,7 +14,22 @@ ErrorType = Literal["tp", "res", "rel"]
 
 
 @dataclass
-class ServiceRecord:
+class ProviderRecord:
+    """Typed data for a provider at a given time."""
+    service_id: str
+    timestamp: int
+    response_time_ms: float
+    throughput_kbps: float
+    cost: float
+    coords: Tuple[float, float]
+    qos: str | None
+    qos_prob: float
+    qos_volatility: float
+
+
+@dataclass
+class ConsumerRecord:
+    """Typed data for a consumer at a given time."""
     service_id: str
     timestamp: int
     response_time_ms: float
@@ -33,7 +48,7 @@ Assignment = List[int]
 Front = List[Tuple[float, float]]
 
 # (producers, consumers) at a time t
-TimeSlice = Tuple[List[dict], List[dict]]
+TimeSlice = Tuple[List[ProviderRecord], List[ConsumerRecord]]
 
 # t -> (producers, consumers)
 TimeSeries = Dict[int, TimeSlice]


### PR DESCRIPTION
## Summary
- Define `ProviderRecord` and `ConsumerRecord` dataclasses and use them in time-series data
- Refactor algorithms, QoS utilities, simulation helpers, and SCS metric functions to operate on typed records
- Update tests to use typed records and validate missing-field errors

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a55252f8548324aba1da5a3fa8cb53