### PR TITLE
Add indicator tests

### DIFF
--- a/tests/test_indicators.py
+++ b/tests/test_indicators.py
@@ -1,0 +1,21 @@
+import math
+import pytest
+
+from multiobjective.indicators import hypervolume_2d, igd, epsilon_additive
+
+
+def test_indicators_on_simple_front():
+    front = [(0.2, 0.3), (0.4, 0.1)]
+    reference = [(0.0, 0.0), (0.2, 0.4)]
+
+    hv = hypervolume_2d(front, ref=(1.0, 1.0))
+    igd_val = igd(front, reference)
+    eps_val = epsilon_additive(front, reference)
+
+    expected_hv = (0.4 - 0.2) * (1.0 - 0.1)
+    expected_igd = (math.sqrt(0.2 ** 2 + 0.3 ** 2) + 0.1) / 2
+    expected_eps = 0.3
+
+    assert hv == pytest.approx(expected_hv)
+    assert igd_val == pytest.approx(expected_igd)
+    assert eps_val == pytest.approx(expected_eps)

--- a/tests/test_rng_reproducibility.py
+++ b/tests/test_rng_reproducibility.py
@@ -2,6 +2,7 @@ import pytest
 
 from multiobjective.algorithms.base import Individual
 from multiobjective.rng import RNGPool
+from multiobjective.types import ProviderRecord, ConsumerRecord
 
 
 def norm_fn(kind, err, t):
@@ -10,21 +11,30 @@ def norm_fn(kind, err, t):
 
 def test_individual_evaluation_reproducible(cfg):
     prods = [
-        {
-            "coords": (0.0, 0.0),
-            "response_time_ms": 1,
-            "throughput_kbps": 1,
-            "cost": 1.0,
-            "qos_prob": 0.5,
-            "qos_volatility": 0.0,
-        }
+        ProviderRecord(
+            service_id="p0",
+            timestamp=0,
+            response_time_ms=1,
+            throughput_kbps=1,
+            cost=1.0,
+            coords=(0.0, 0.0),
+            qos=None,
+            qos_prob=0.5,
+            qos_volatility=0.0,
+        )
     ]
     cons = [
-        {
-            "coords": (0.0, 0.0),
-            "response_time_ms": 1,
-            "throughput_kbps": 1,
-        }
+        ConsumerRecord(
+            service_id="c0",
+            timestamp=0,
+            response_time_ms=1,
+            throughput_kbps=1,
+            cost=0.0,
+            coords=(0.0, 0.0),
+            qos=None,
+            qos_prob=0.0,
+            qos_volatility=0.0,
+        )
     ]
 
     def run(run_order):


### PR DESCRIPTION
## Summary
- exercise hypervolume, IGD, and epsilon-additive indicator functions on a small synthetic front
- ensure RNG reproducibility test uses typed ProviderRecord and ConsumerRecord objects

## Testing
- `pytest -q tests`


------
https://chatgpt.com/codex/tasks/task_e_68a61ffe60308324826e95d4392cf2d8