### PR TITLE
Add experiment output structure test

### DIFF
--- a/tests/test_experiment_outputs.py
+++ b/tests/test_experiment_outputs.py
@@ -1,0 +1,57 @@
+import pytest
+
+from multiobjective.config import Config
+import multiobjective.experiment as experiment
+from multiobjective.metrics.scs import SCSComponents
+from multiobjective import algorithms
+
+
+@pytest.fixture
+def tiny_cfg() -> Config:
+    """Small configuration with deterministic seed."""
+    return Config(
+        num_times=2,
+        num_services=6,
+        coverage_fraction=1.0,
+        master_seed=0,
+        scs_mc_rollouts=1,
+    )
+
+
+def test_run_experiment_outputs_structure(tiny_cfg, monkeypatch):
+    """run_experiment should produce structured numeric outputs."""
+
+    def dummy_alg(cfg, rng_pool, records, cost_per, err_type, metrics, streaks, norm_fn):
+        series = [0.0] * cfg.num_times
+        for t in range(cfg.num_times):
+            metrics.record("dummy", err_type, t, [])
+        return series, series, series
+
+    monkeypatch.setattr(algorithms, "ALG_REGISTRY", {"dummy": dummy_alg})
+    monkeypatch.setattr(experiment, "scs", lambda *a, **k: (0.0, SCSComponents()))
+    monkeypatch.setattr(
+        experiment,
+        "expected_scs_next",
+        lambda *a, **k: (0.0, SCSComponents()),
+    )
+
+    result = experiment.run_experiment(tiny_cfg)
+
+    assert {"series", "indicators", "scs", "meta"} <= result.keys()
+    assert set(result["scs"].keys()) == {"tp", "res", "E_tp", "E_res"}
+
+    for values in result["scs"].values():
+        assert len(values) == tiny_cfg.num_times
+        assert all(isinstance(v, (int, float)) for v in values)
+
+    for series in result["series"].values():
+        for section in ("errors", "costs", "stds"):
+            for values in series[section].values():
+                assert len(values) == tiny_cfg.num_times
+                assert all(isinstance(v, (int, float)) for v in values)
+
+    for metrics in result["indicators"].values():
+        for by_err in metrics.values():
+            for values in by_err.values():
+                assert len(values) == tiny_cfg.num_times
+                assert all(isinstance(v, (int, float)) for v in values)

--- a/tests/test_rng_reproducibility.py
+++ b/tests/test_rng_reproducibility.py
@@ -2,6 +2,7 @@ import pytest
 
 from multiobjective.algorithms.base import Individual
 from multiobjective.rng import RNGPool
+from multiobjective.types import ProviderRecord, ConsumerRecord
 
 
 def norm_fn(kind, err, t):
@@ -10,21 +11,30 @@ def norm_fn(kind, err, t):
 
 def test_individual_evaluation_reproducible(cfg):
     prods = [
-        {
-            "coords": (0.0, 0.0),
-            "response_time_ms": 1,
-            "throughput_kbps": 1,
-            "cost": 1.0,
-            "qos_prob": 0.5,
-            "qos_volatility": 0.0,
-        }
+        ProviderRecord(
+            service_id="p1",
+            timestamp=0,
+            response_time_ms=1,
+            throughput_kbps=1,
+            cost=1.0,
+            coords=(0.0, 0.0),
+            qos=None,
+            qos_prob=0.5,
+            qos_volatility=0.0,
+        )
     ]
     cons = [
-        {
-            "coords": (0.0, 0.0),
-            "response_time_ms": 1,
-            "throughput_kbps": 1,
-        }
+        ConsumerRecord(
+            service_id="c1",
+            timestamp=0,
+            response_time_ms=1,
+            throughput_kbps=1,
+            cost=0.0,
+            coords=(0.0, 0.0),
+            qos=None,
+            qos_prob=0.0,
+            qos_volatility=0.0,
+        )
     ]
 
     def run(run_order):


### PR DESCRIPTION
## Summary
- add regression test verifying structure and numeric lengths of run_experiment outputs
- convert RNG reproducibility test to use typed ProviderRecord/ConsumerRecord

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a61ffdf790832483dd48d37548b07c