### PR TITLE
Add plotting example and improve record handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,27 @@
+# Multiobjective Simulation
+
+This repository provides tools for running multi-objective service selection
+experiments. It includes several algorithms and helpers for analysing the
+resulting error and cost trade-offs.
+
+## Example visualisation
+
+An example script demonstrates how to run a small experiment and plot the
+results using `matplotlib`.
+
+### Requirements
+
+```bash
+pip install matplotlib
+```
+
+### Running the example
+
+From the repository root execute:
+
+```bash
+python examples/plot_results.py
+```
+
+The script runs `run_experiment` with a tiny configuration and displays error
+and cost trends for two algorithms alongside their final error–cost tradeoff.

--- a/algorithms/base.py
+++ b/algorithms/base.py
@@ -5,6 +5,7 @@ from ..config import Config
 from ..rng import RNGPool
 from ..metrics.scs import blended_error
 from ..defaults import OU_PARAMS_DEFAULT
+from ..qos import _attr
 
 
 class Algorithm(Protocol):
@@ -51,10 +52,10 @@ class Individual:
                 )
             )
 
-            r = p.qos_prob
-            v = p.qos_volatility
+            r = _attr(p, "qos_prob")
+            v = _attr(p, "qos_volatility")
             costs.append(
-                ctx_norm_cost(p.cost, t, norm_fn)
+                ctx_norm_cost(_attr(p, "cost"), t, norm_fn)
                 * (1.0 + lambda_vol * v)
                 / (max(r, 1e-6) ** gamma_qos)
             )

--- a/examples/plot_results.py
+++ b/examples/plot_results.py
@@ -1,0 +1,126 @@
+"""Example script to run a small experiment and plot results.
+
+This script runs :func:`multiobjective.experiment.run_experiment` with a
+lightweight configuration and produces a few basic visualisations of the
+resulting metrics using the helper functions in :mod:`multiobjective.plotting`.
+"""
+import matplotlib
+matplotlib.use("Agg")  # use a non-interactive backend for example usage
+
+from pathlib import Path
+import sys
+
+# Ensure the project root's parent is on the Python path and avoid name clashes
+_script_dir = Path(__file__).resolve().parent
+_repo_root = _script_dir.parent
+_parent = _repo_root.parent
+for p in ("", str(_script_dir), str(_repo_root)):
+    if p in sys.path:
+        sys.path.remove(p)
+sys.path.append(str(_parent))
+
+import numpy as np
+from multiobjective.config import Config, NSGAConfig, PSOConfig, GWOConfig, coverage_radius
+from multiobjective.experiment import run_experiment
+from multiobjective.plotting import plot_metric_over_time, plot_tradeoff
+from multiobjective.simulation import euclidean_distance
+from multiobjective.metrics.scs import blended_error
+from multiobjective.defaults import OU_PARAMS_DEFAULT
+from multiobjective import algorithms
+
+
+def main() -> None:
+    """Execute a minimal experiment and display several plots."""
+    # Limit the algorithm registry so the example stays quick to run.
+    # Disable heavy SCS computations for the example.
+    def _noop_scs(*args, **kwargs):
+        return 0.0, None
+
+    _experiment_module = __import__("multiobjective.experiment", fromlist=["scs"])
+    _experiment_module.scs = _noop_scs
+    _experiment_module.expected_scs_next = lambda *a, **k: (0.0, None)
+
+    # Define two lightweight algorithms for demonstration purposes.
+    def random_match(cfg, rng_pool, records, cost_per, err_type, metrics, _streaks, norm_fn):
+        errors, costs, stds = [], [], []
+        radius = coverage_radius(cfg)
+        for t in range(cfg.num_times):
+            rng = rng_pool.for_("greedy", t)
+            scs_rng = rng_pool.for_("scs", t)
+            prods, cons = records[t]
+            curr_max, curr_min = max(cost_per[f"{t}"]), min(cost_per[f"{t}"])
+            matched = []
+            for c in cons:
+                viable = [p for p in prods if euclidean_distance(p, c) <= radius]
+                if not viable:
+                    viable = prods  # fall back to any provider
+                p = rng.choice(viable)
+                err = blended_error(err_type, p, c, t, cfg, norm_fn, scs_rng,
+                                    ou_params=OU_PARAMS_DEFAULT)
+                cost_norm = (p.cost - curr_min) / (curr_max - curr_min + 1e-12)
+                matched.append((err, cost_norm))
+            errs = [m[0] for m in matched]; cs = [m[1] for m in matched]
+            errors.append(float(np.mean(errs)))
+            costs.append(float(np.mean(cs)))
+            stds.append(float(np.std(errs)) if len(errs) > 1 else 0.0)
+            metrics.record("random", err_type, t, [(errors[-1], costs[-1])])
+        return errors, costs, stds
+
+    def min_cost_match(cfg, rng_pool, records, cost_per, err_type, metrics, _streaks, norm_fn):
+        errors, costs, stds = [], [], []
+        radius = coverage_radius(cfg)
+        for t in range(cfg.num_times):
+            scs_rng = rng_pool.for_("scs", t)
+            prods, cons = records[t]
+            curr_max, curr_min = max(cost_per[f"{t}"]), min(cost_per[f"{t}"])
+            matched = []
+            for c in cons:
+                viable = [p for p in prods if euclidean_distance(p, c) <= radius]
+                if not viable:
+                    viable = prods
+                p = min(viable, key=lambda x: x.cost)
+                err = blended_error(err_type, p, c, t, cfg, norm_fn, scs_rng,
+                                    ou_params=OU_PARAMS_DEFAULT)
+                cost_norm = (p.cost - curr_min) / (curr_max - curr_min + 1e-12)
+                matched.append((err, cost_norm))
+            errs = [m[0] for m in matched]; cs = [m[1] for m in matched]
+            errors.append(float(np.mean(errs)))
+            costs.append(float(np.mean(cs)))
+            stds.append(float(np.std(errs)) if len(errs) > 1 else 0.0)
+            metrics.record("min_cost", err_type, t, [(errors[-1], costs[-1])])
+        return errors, costs, stds
+
+    algorithms.ALG_REGISTRY = {"random": random_match, "min_cost": min_cost_match}
+
+    cfg = Config(
+        num_times=5,
+        num_services=10,
+        ratio_str="one_one",
+        scs_lookahead_weight=0.0,
+        scs_mc_rollouts=4,
+        nsga=NSGAConfig(population_size=10, max_generations=5, patience=5),
+        pso=PSOConfig(swarm_size=10, max_iterations=5, archive_size=10),
+        gwo=GWOConfig(wolf_size=10, max_iters=5, archive_size=10),
+    )
+
+    outputs = run_experiment(cfg)
+    series = outputs["series"]
+    times = list(range(cfg.num_times))
+
+    # Choose the algorithms to visualise
+    algs = ["random", "min_cost"]
+    error_series = [series[a]["errors"]["tp"] for a in algs]
+    cost_series = [series[a]["costs"]["tp"] for a in algs]
+
+    # Plot error and cost trajectories
+    plot_metric_over_time(times, error_series, algs, "Topology error over time", "Normalised error")
+    plot_metric_over_time(times, cost_series, algs, "Cost over time", "Normalised cost")
+
+    # Show error–cost tradeoffs for the final time step
+    final_errors = [errs[-1] for errs in error_series]
+    final_costs = [cs[-1] for cs in cost_series]
+    plot_tradeoff(final_errors, final_costs, algs, "Error–Cost tradeoff at final step")
+
+
+if __name__ == "__main__":
+    main()

--- a/metrics/scs.py
+++ b/metrics/scs.py
@@ -138,7 +138,8 @@ def blended_error(
     """
     base = norm_fn(err_type, reg_err(p, c, err_type), t)
     scs_cfg = cfg.scs
-    if not scs_cfg.enabled:
+    # If SCS is disabled or records lack QoS information, return base error.
+    if not scs_cfg.enabled or isinstance(p, dict) or isinstance(c, dict):
         return base
 
     ou = ou_params or OUParams(cfg.ou_theta, cfg.ou_sigma, cfg.delta_t)

--- a/qos.py
+++ b/qos.py
@@ -4,6 +4,11 @@ from .types import ProviderRecord, ConsumerRecord
 
 QoSState = Literal["Low","Medium","High"]
 
+
+def _attr(obj, name):
+    """Return attribute ``name`` from ``obj`` supporting dict access."""
+    return obj[name] if isinstance(obj, dict) else getattr(obj, name)
+
 def classify_qos(resp_norm: float, thrp_norm: float, alpha: float=0.5) -> QoSState:
     score = alpha*resp_norm + (1-alpha)*(1-thrp_norm)
     if score >= 0.66: return "Low"
@@ -20,7 +25,7 @@ def smooth_qos(prev_qos: QoSState, inferred_qos: QoSState, transition_matrix: di
 
 def reg_err(p: ProviderRecord, c: ConsumerRecord, kind: str) -> float:
     if kind == "tp":
-        prov, req = p.throughput_kbps, c.throughput_kbps
+        prov, req = _attr(p, "throughput_kbps"), _attr(c, "throughput_kbps")
         if prov < req:
             return (req - prov) / (req + 1e-12)
         if req < prov:
@@ -28,7 +33,7 @@ def reg_err(p: ProviderRecord, c: ConsumerRecord, kind: str) -> float:
             return abs(0.5 * math.log(x))
         return 0.0
     elif kind == "res":
-        prov, req = p.response_time_ms, c.response_time_ms
+        prov, req = _attr(p, "response_time_ms"), _attr(c, "response_time_ms")
         if prov < req:
             x = max(0.005 * ((req - prov) / (req + 1e-12)), 1e-6)
             return abs(0.5 * math.log(x))
@@ -37,5 +42,5 @@ def reg_err(p: ProviderRecord, c: ConsumerRecord, kind: str) -> float:
         return 0.0
     else:
         # relative
-        den = (c.response_time_ms + c.throughput_kbps) or 1.0
-        return abs(1 - ((p.response_time_ms + p.throughput_kbps) / den))
+        den = (_attr(c, "response_time_ms") + _attr(c, "throughput_kbps")) or 1.0
+        return abs(1 - ((_attr(p, "response_time_ms") + _attr(p, "throughput_kbps")) / den))


### PR DESCRIPTION
## Summary
- add `examples/plot_results.py` to run a tiny experiment and plot error/cost trends and a final tradeoff
- document how to run the example in `README.md`
- make QoS utilities, SCS blend, and Individual evaluation tolerate dict-style records

## Testing
- `python examples/plot_results.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a61fff0b2c8324a2d68dbeaae2545c