### PR TITLE
Use service IDs for streak tracking

### DIFF
--- a/multiobjective/algorithms/greedy.py
+++ b/multiobjective/algorithms/greedy.py
@@ -5,7 +5,7 @@ from ..config import Config, coverage_radius
 from ..rng import RNGPool
 from ..simulation import euclidean_distance
 from ..qos import reg_err
-from ..streaks import StreakTracker
+from ..streaks import StreakTracker, sid_to_pid_cid
 from ..indicators import MetricsRecorder
 from ..defaults import OU_PARAMS_DEFAULT
 # and, if you need the helper:
@@ -55,7 +55,11 @@ def greedy_run(cfg: Config, rng_pool: RNGPool, records: dict, cost_per: dict,
             best_i = idxs[int(np.argmin(scores))]
             p = prods[best_i]
             # streak continuity bookkeeping
-            streaks.update(t, f"c{c.service_id[1:]}", f"p{p.service_id[1:]}")
+            streaks.update(
+                t,
+                sid_to_pid_cid(c.service_id, cfg.num_providers),
+                sid_to_pid_cid(p.service_id, cfg.num_providers),
+            )
             e = blended_error(
                 err_type, p, c, t, cfg, norm_fn, scs_rng,
                 ou_params=OU_PARAMS_DEFAULT,

--- a/multiobjective/algorithms/nsga2.py
+++ b/multiobjective/algorithms/nsga2.py
@@ -55,12 +55,15 @@ def run_nsga2(cfg: Config, rng_pool: RNGPool, records: dict, cost_per: dict,
                 p1 = tournament_select(pop, cfg.nsga.tournament_size, rng)
                 p2 = tournament_select(pop, cfg.nsga.tournament_size, rng)
                 c1, c2 = _sbx(p1, p2, cfg.nsga.crossover_eta, pc, rng, len(cons), len(prods))
-                #_eval(c1, prods, cons, err_type, norm_fn, t, cfg); _eval(c2, prods, cons, err_type, norm_fn, t, cfg)
-                _eval(c1, prods, cons, err_type, norm_fn, t, cfg, rng, transition_matrix)
-                _eval(c2, prods, cons, err_type, norm_fn, t, cfg, rng, transition_matrix)
-                m1 = _poly_mut(c1, cfg.nsga.mutation_eta, pm, rng, len(prods), cons); _eval(m1, prods, cons, err_type, norm_fn, t, cfg); off.append(m1)
+                _eval(c1, prods, cons, err_type, norm_fn, t, cfg, rng_pool, transition_matrix)
+                _eval(c2, prods, cons, err_type, norm_fn, t, cfg, rng_pool, transition_matrix)
+                m1 = _poly_mut(c1, cfg.nsga.mutation_eta, pm, rng, len(prods), cons)
+                _eval(m1, prods, cons, err_type, norm_fn, t, cfg, rng_pool, transition_matrix)
+                off.append(m1)
                 if len(off) < pop_size:
-                    m2 = _poly_mut(c2, cfg.nsga.mutation_eta, pm, rng, len(prods), cons); _eval(m2, prods, cons, err_type, norm_fn, t, cfg); off.append(m2)
+                    m2 = _poly_mut(c2, cfg.nsga.mutation_eta, pm, rng, len(prods), cons)
+                    _eval(m2, prods, cons, err_type, norm_fn, t, cfg, rng_pool, transition_matrix)
+                    off.append(m2)
 
             combined = pop + off
             fronts = fast_non_dominated_sort(combined)


### PR DESCRIPTION
## Summary
- Derive `StreakTracker` IDs from actual service identifiers and pass them through the greedy algorithm via `sid_to_pid_cid`
- Handle algorithms without streak tracking and forward RNG pool correctly in NSGA2 evaluation

## Testing
- `pytest -q`
- `python -m multiobjective.cli run --out results.json` *(fails: KeyboardInterrupt due to long runtime)*

------
https://chatgpt.com/codex/tasks/task_e_68a667451cc88324b57a071521ad3b2b