### PR TITLE
Handle small MOGWO archives

### DIFF
--- a/multiobjective/algorithms/mogwo.py
+++ b/multiobjective/algorithms/mogwo.py
@@ -87,7 +87,9 @@ def run_mogwo(cfg: Config, rng_pool: RNGPool, records: dict, cost_per: dict,
                 arr_pos, arr_obj = zip(*archive)
                 cd = crowding_distance(list(arr_obj))
                 idx = np.argsort(cd)[::-1]
-                alpha, beta, delta = arr_pos[idx[0]], arr_pos[idx[1]], arr_pos[idx[2]]
+                alpha = arr_pos[idx[0]]
+                beta = arr_pos[idx[1]] if len(arr_pos) > 1 else alpha
+                delta = arr_pos[idx[2]] if len(arr_pos) > 2 else beta
             else:
                 alpha = beta = delta = wolves[0]
 

--- a/tests/test_mogwo_small_archive.py
+++ b/tests/test_mogwo_small_archive.py
@@ -1,0 +1,30 @@
+import multiobjective.experiment as experiment
+from multiobjective.config import Config, NSGAConfig, PSOConfig, GWOConfig
+from multiobjective.algorithms.mogwo import run_mogwo
+import multiobjective.algorithms as algorithms
+
+
+def test_mogwo_handles_small_archive(monkeypatch):
+    cfg = Config(
+        num_times=1,
+        num_services=4,
+        coverage_fraction=0.1,
+        nsga=NSGAConfig(population_size=4, max_generations=1),
+        pso=PSOConfig(swarm_size=4, max_iterations=1),
+        gwo=GWOConfig(wolf_size=2, max_iters=1),
+    )
+
+    monkeypatch.setattr(algorithms, "ALG_REGISTRY", {"mogwo": run_mogwo})
+
+    class DummyStreak:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def update(self, *args, **kwargs):
+            pass
+
+    monkeypatch.setattr(experiment, "StreakTracker", DummyStreak)
+
+    result = experiment.run_experiment(cfg)
+
+    assert "mogwo" in result["series"]


### PR DESCRIPTION
## Summary
- Add fallbacks for alpha, beta, and delta in MOGWO when the archive has <3 entries
- Add regression test to ensure run_experiment works with tiny MOGWO archives

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a68f90f4a883248145573a655079cc