### PR TITLE
Use service IDs directly for streak tracking

### DIFF
--- a/multiobjective/algorithms/greedy.py
+++ b/multiobjective/algorithms/greedy.py
@@ -5,7 +5,7 @@ from ..config import Config, coverage_radius
 from ..rng import RNGPool
 from ..simulation import euclidean_distance
 from ..qos import reg_err
-from ..streaks import StreakTracker, sid_to_pid_cid
+from ..streaks import StreakTracker
 from ..indicators import MetricsRecorder
 from ..defaults import OU_PARAMS_DEFAULT
 # and, if you need the helper:
@@ -55,11 +55,7 @@ def greedy_run(cfg: Config, rng_pool: RNGPool, records: dict, cost_per: dict,
             best_i = idxs[int(np.argmin(scores))]
             p = prods[best_i]
             # streak continuity bookkeeping
-            streaks.update(
-                t,
-                sid_to_pid_cid(c.service_id, cfg.num_providers),
-                sid_to_pid_cid(p.service_id, cfg.num_providers),
-            )
+            streaks.update(t, c.service_id, p.service_id)
             e = blended_error(
                 err_type, p, c, t, cfg, norm_fn, scs_rng,
                 ou_params=OU_PARAMS_DEFAULT,

--- a/multiobjective/experiment.py
+++ b/multiobjective/experiment.py
@@ -3,14 +3,14 @@ from .config import Config, coverage_radius
 from .rng import RNGPool
 from .data import RecordBuilder
 from .indicators import MetricsRecorder
-from .streaks import StreakTracker, sid_to_pid_cid
+from .streaks import StreakTracker
 from .metrics import SCSConfig, scs, expected_scs_next
 from .qos import reg_err
 from .types import ProviderRecord, ConsumerRecord
 
 def run_experiment(cfg: Config) -> dict:
     rng_pool = RNGPool(cfg.master_seed, cfg.num_times)
-    records, cost_per_dict, T, providers, consumers = RecordBuilder(cfg, rng_pool)
+    records, cost_per_dict, T, _, _ = RecordBuilder(cfg, rng_pool)
     num_providers, num_consumers = cfg.num_providers, cfg.num_consumers
 
     # normalization bounds (per-time) for errors + cost
@@ -40,7 +40,7 @@ def run_experiment(cfg: Config) -> dict:
         raise ValueError(kind)
 
     # trackers & metrics
-    consumer_ids = [sid_to_pid_cid(sid, num_providers) for sid in consumers]
+    consumer_ids = [c.service_id for c in records[0][1]]
     streaks = StreakTracker(consumer_ids, cfg.num_times)
     metrics = MetricsRecorder(cfg.num_times)
 

--- a/multiobjective/streaks.py
+++ b/multiobjective/streaks.py
@@ -1,6 +1,15 @@
 from typing import Dict, List, Tuple
 
 def sid_to_pid_cid(sid: str, num_providers: int) -> str:
+    """Normalize service IDs to provider/consumer form.
+
+    If the ID already begins with ``"p"`` or ``"c"`` it is returned as-is.
+    Otherwise, it is assumed to be of the form ``"S<number>"`` and is mapped
+    to ``"p<number>"`` if the index refers to a provider or ``"c<number>``
+    for consumers.
+    """
+    if sid.startswith("p") or sid.startswith("c"):
+        return sid
     k = int(sid[1:])
     return f"p{k}" if k <= num_providers else f"c{k - num_providers}"
 


### PR DESCRIPTION
## Summary
- Build `consumer_ids` from actual `ConsumerRecord` objects in `run_experiment`
- Pass service IDs directly to `StreakTracker.update` in greedy algorithm
- Make `sid_to_pid_cid` a no-op when ID already starts with `p` or `c`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a773ab7afc8324bfc396e13ac1dbbe