### PR TITLE
Handle missing coverage in experiment normalization

### DIFF
--- a/multiobjective/experiment.py
+++ b/multiobjective/experiment.py
@@ -7,6 +7,7 @@ from .streaks import StreakTracker, sid_to_pid_cid
 from .metrics import SCSConfig, scs, expected_scs_next
 from .qos import reg_err
 from .types import ProviderRecord, ConsumerRecord
+from .errors import CoverageError
 
 def run_experiment(cfg: Config) -> dict:
     rng_pool = RNGPool(cfg.master_seed, cfg.num_times)
@@ -19,11 +20,17 @@ def run_experiment(cfg: Config) -> dict:
     for t in range(cfg.num_times):
         prods, cons = records[t]
         tp_errs, res_errs = [], []
-        for p in prods:
-            for c in cons:
+        for c in cons:
+            feasible = False
+            for p in prods:
                 if _within(p, c, rad):
+                    feasible = True
                     tp_errs.append(reg_err(p, c, "tp"))
                     res_errs.append(reg_err(p, c, "res"))
+            if not feasible:
+                raise CoverageError(consumer_id=c.service_id, t=t, radius=rad)
+        if not tp_errs or not res_errs:
+            raise CoverageError(consumer_id="*", t=t, radius=rad)
         per_time_bounds[f"{t}"] = (
             max(tp_errs), max(res_errs), min(tp_errs), min(res_errs),
             min(cost_per_dict[f"{t}"]), max(cost_per_dict[f"{t}"])

--- a/tests/test_experiment.py
+++ b/tests/test_experiment.py
@@ -2,6 +2,8 @@ import multiobjective.experiment as experiment
 from multiobjective.config import Config, NSGAConfig, PSOConfig, GWOConfig
 from multiobjective.algorithms.greedy import greedy_run
 import multiobjective.algorithms as algorithms
+import pytest
+from multiobjective.errors import CoverageError
 
 
 def test_run_experiment_minimal(monkeypatch):
@@ -29,3 +31,14 @@ def test_run_experiment_minimal(monkeypatch):
 
     assert {"series", "indicators", "scs", "meta"} <= set(result.keys())
     assert "greedy" in result["series"]
+
+
+def test_run_experiment_no_feasible_pairs():
+    cfg = Config(
+        num_times=1,
+        num_services=4,
+        coverage_fraction=0.0,
+    )
+
+    with pytest.raises(CoverageError):
+        experiment.run_experiment(cfg)


### PR DESCRIPTION
## Summary
- Safely handle time steps with no feasible provider-consumer pairs by raising `CoverageError`
- Add regression test to ensure experiments fail gracefully when zero feasible pairs occur

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a773ae3c208324a003f323d461223b