### PR TITLE
Add error-bar plotting helper

### DIFF
--- a/examples/plot_results.py
+++ b/examples/plot_results.py
@@ -22,7 +22,11 @@ sys.path.append(str(_parent))
 import numpy as np
 from multiobjective.config import Config, NSGAConfig, PSOConfig, GWOConfig, coverage_radius
 from multiobjective.experiment import run_experiment
-from multiobjective.plotting import plot_metric_over_time, plot_tradeoff
+from multiobjective.plotting import (
+    plot_metric_over_time,
+    plot_metric_with_std,
+    plot_tradeoff,
+)
 from multiobjective.simulation import euclidean_distance
 from multiobjective.metrics.scs import blended_error
 from multiobjective.defaults import OU_PARAMS_DEFAULT
@@ -110,10 +114,18 @@ def main() -> None:
     # Choose the algorithms to visualise
     algs = ["random", "min_cost"]
     error_series = [series[a]["errors"]["tp"] for a in algs]
+    std_series = [series[a]["stds"]["tp"] for a in algs]
     cost_series = [series[a]["costs"]["tp"] for a in algs]
 
-    # Plot error and cost trajectories
-    plot_metric_over_time(times, error_series, algs, "Topology error over time", "Normalised error")
+    # Plot error and cost trajectories (error with variability)
+    plot_metric_with_std(
+        times,
+        error_series,
+        std_series,
+        algs,
+        "Topology error over time",
+        "Normalised error",
+    )
     plot_metric_over_time(times, cost_series, algs, "Cost over time", "Normalised cost")
 
     # Show error–cost tradeoffs for the final time step

--- a/multiobjective/plotting.py
+++ b/multiobjective/plotting.py
@@ -7,6 +7,34 @@ def plot_metric_over_time(times, series, labels, title, ylabel):
         plt.plot(times, ys, marker="o", label=lab)
     plt.title(title); plt.xlabel("t"); plt.ylabel(ylabel); plt.grid(True); plt.legend(); plt.show()
 
+def plot_metric_with_std(times, series, stds, labels, title, ylabel):
+    """Plot metric trajectories with mean and standard deviation.
+
+    Parameters
+    ----------
+    times : sequence
+        The x-axis values, typically representing time steps.
+    series : sequence of sequences
+        Mean metric values for each algorithm.
+    stds : sequence of sequences
+        Standard deviations corresponding to ``series``.
+    labels : sequence of str
+        Labels for each algorithm.
+    title : str
+        Title for the plot.
+    ylabel : str
+        Label for the y-axis.
+    """
+    plt.figure(figsize=(10,4))
+    for ys, ss, lab in zip(series, stds, labels):
+        plt.errorbar(times, ys, yerr=ss, marker="o", label=lab)
+    plt.title(title)
+    plt.xlabel("t")
+    plt.ylabel(ylabel)
+    plt.grid(True)
+    plt.legend()
+    plt.show()
+
 def plot_tradeoff(errors, costs, labels, title):
     plt.figure(figsize=(8,6))
     mk = ["o","s","^","x","d","*"]


### PR DESCRIPTION
## Summary
- add `plot_metric_with_std` helper to wrap `plt.errorbar`
- show error variability over time in `examples/plot_results.py`

## Testing
- `pytest >/tmp/unit.log && tail -n 20 /tmp/unit.log`

------
https://chatgpt.com/codex/tasks/task_e_68a7a61a1e388324a4ecedc16ddae393