### PR TITLE
Add indicator plotting utilities

### DIFF
--- a/examples/plot_results.py
+++ b/examples/plot_results.py
@@ -22,7 +22,11 @@ sys.path.append(str(_parent))
 import numpy as np
 from multiobjective.config import Config, NSGAConfig, PSOConfig, GWOConfig, coverage_radius
 from multiobjective.experiment import run_experiment
-from multiobjective.plotting import plot_metric_over_time, plot_tradeoff
+from multiobjective.plotting import (
+    plot_metric_over_time,
+    plot_tradeoff,
+    plot_indicators_over_time,
+)
 from multiobjective.simulation import euclidean_distance
 from multiobjective.metrics.scs import blended_error
 from multiobjective.defaults import OU_PARAMS_DEFAULT
@@ -113,13 +117,20 @@ def main() -> None:
     cost_series = [series[a]["costs"]["tp"] for a in algs]
 
     # Plot error and cost trajectories
-    plot_metric_over_time(times, error_series, algs, "Topology error over time", "Normalised error")
-    plot_metric_over_time(times, cost_series, algs, "Cost over time", "Normalised cost")
+    plot_metric_over_time(
+        times, error_series, algs, "Topology error over time", "Normalised error"
+    )
+    plot_metric_over_time(
+        times, cost_series, algs, "Cost over time", "Normalised cost"
+    )
 
     # Show error–cost tradeoffs for the final time step
     final_errors = [errs[-1] for errs in error_series]
     final_costs = [cs[-1] for cs in cost_series]
     plot_tradeoff(final_errors, final_costs, algs, "Error–Cost tradeoff at final step")
+
+    # Visualise quality indicators across time
+    plot_indicators_over_time(times, outputs["indicators"], algs, aggregate=True)
 
 
 if __name__ == "__main__":

--- a/multiobjective/plotting.py
+++ b/multiobjective/plotting.py
@@ -1,15 +1,97 @@
 import matplotlib.pyplot as plt
 import numpy as np
 
-def plot_metric_over_time(times, series, labels, title, ylabel):
-    plt.figure(figsize=(10,4))
+
+def plot_metric_over_time(times, series, labels, title, ylabel, ax=None):
+    """Plot a generic metric's trajectory for multiple algorithms.
+
+    Parameters
+    ----------
+    times:
+        Sequence of time points.
+    series:
+        Sequence of ``y`` value sequences – one per algorithm.
+    labels:
+        Algorithm labels corresponding to ``series``.
+    title:
+        Title for the plot.
+    ylabel:
+        Label for the y axis.
+    ax:
+        Optional matplotlib axis to plot on. When ``None`` (default) a new
+        figure and axis are created and ``plt.show`` is called.
+    """
+
+    created_fig = ax is None
+    if created_fig:
+        fig, ax = plt.subplots(figsize=(10, 4))
     for ys, lab in zip(series, labels):
-        plt.plot(times, ys, marker="o", label=lab)
-    plt.title(title); plt.xlabel("t"); plt.ylabel(ylabel); plt.grid(True); plt.legend(); plt.show()
+        ax.plot(times, ys, marker="o", label=lab)
+    ax.set_title(title)
+    ax.set_xlabel("t")
+    ax.set_ylabel(ylabel)
+    ax.grid(True)
+    ax.legend()
+    if created_fig:
+        plt.show()
+    return ax
 
 def plot_tradeoff(errors, costs, labels, title):
-    plt.figure(figsize=(8,6))
-    mk = ["o","s","^","x","d","*"]
-    for i, (e,c,l) in enumerate(zip(errors, costs, labels)):
-        plt.scatter(e, c, marker=mk[i%len(mk)], label=l)
-    plt.xlabel("Error"); plt.ylabel("Cost"); plt.title(title); plt.grid(True); plt.legend(); plt.show()
+    plt.figure(figsize=(8, 6))
+    mk = ["o", "s", "^", "x", "d", "*"]
+    for i, (e, c, l) in enumerate(zip(errors, costs, labels)):
+        plt.scatter(e, c, marker=mk[i % len(mk)], label=l)
+    plt.xlabel("Error")
+    plt.ylabel("Cost")
+    plt.title(title)
+    plt.grid(True)
+    plt.legend()
+    plt.show()
+
+
+def plot_indicators_over_time(times, indicators, algs, aggregate=False):
+    """Visualise HV/IGD/EPS indicators for each algorithm over time.
+
+    Parameters
+    ----------
+    times:
+        Sequence of time points.
+    indicators:
+        Mapping of algorithm -> error-type -> indicator name -> values.
+    algs:
+        Iterable of algorithm names to include in the plots.
+    aggregate:
+        When ``True``, plot all indicators in a single multi-panel figure.
+        Otherwise, individual figures are produced via
+        :func:`plot_metric_over_time`.
+    """
+
+    metrics = ["HV", "IGD", "EPS"]
+    err_types = ["tp", "res"]
+
+    if aggregate:
+        fig, axes = plt.subplots(
+            len(err_types),
+            len(metrics),
+            figsize=(5 * len(metrics), 3 * len(err_types)),
+            sharex=True,
+        )
+        for r, te in enumerate(err_types):
+            for c, m in enumerate(metrics):
+                ax = axes[r, c]
+                series = [indicators[a][te][m] for a in algs]
+                plot_metric_over_time(times, series, algs, f"{m} ({te})", m, ax=ax)
+        fig.tight_layout()
+        plt.show()
+    else:
+        for te in err_types:
+            for m in metrics:
+                series = [indicators[a][te][m] for a in algs]
+                plot_metric_over_time(
+                    times,
+                    series,
+                    algs,
+                    f"{m} ({te}) over time",
+                    m,
+                )
+


### PR DESCRIPTION
## Summary
- add `plot_indicators_over_time` to visualise HV/IGD/EPS across algorithms
- extend `plot_metric_over_time` with optional axis parameter
- update example script to plot quality indicators

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a7a61ea8e8832489614023eb1450e4