### PR TITLE
Add plotting helpers for indicator metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Then load the JSON and generate plots:
 ```bash
 python - <<'PY'
 import json
-from multiobjective.plotting import plot_metric_over_time, plot_tradeoff
+from multiobjective.plotting import plot_metric_over_time, plot_tradeoff, plot_indicator_metric
 
 # Load CLI output
 with open("results.json") as f:
@@ -56,6 +56,15 @@ plot_metric_over_time(times,
 plot_metric_over_time(times,
     [series[a]["costs"]["tp"] for a in algs],
     algs, "Cost over time", "Normalised cost")
+
+# Plot a quality indicator (e.g. hypervolume)
+plot_indicator_metric(
+    results["indicators"],
+    "HV",
+    "tp",
+    "Topology hypervolume over time",
+    "Hypervolume",
+)
 
 # Plot final trade-off
 plot_tradeoff(

--- a/examples/plot_results.py
+++ b/examples/plot_results.py
@@ -26,6 +26,7 @@ from multiobjective.plotting import (
     plot_metric_over_time,
     plot_metric_with_std,
     plot_tradeoff,
+    plot_indicator_metric,
 )
 from multiobjective.simulation import euclidean_distance
 from multiobjective.metrics.scs import blended_error
@@ -131,6 +132,15 @@ def main() -> None:
     plot_metric_over_time(times, cost_series, algs, "Cost over time", "Normalised cost")
     plot_metric_over_time(times, res_error_series, algs, "Resource error over time", "Normalised error")
     plot_metric_over_time(times, res_cost_series, algs, "Resource cost over time", "Normalised cost")
+
+    # Plot hypervolume indicator for topology error fronts
+    plot_indicator_metric(
+        results["indicators"],
+        "HV",
+        "tp",
+        "Topology hypervolume over time",
+        "Hypervolume",
+    )
 
     # Plot actual vs expected SCS for topology and resilience errors
     scs_tp = results["scs"]["tp"]

--- a/multiobjective/plotting.py
+++ b/multiobjective/plotting.py
@@ -49,3 +49,58 @@ def plot_tradeoff(errors, costs, labels, title):
     for i, (e,c,l) in enumerate(zip(errors, costs, labels)):
         plt.scatter(e, c, marker=mk[i%len(mk)], label=l)
     plt.xlabel("Error"); plt.ylabel("Cost"); plt.title(title); plt.grid(True); plt.legend(); plt.show()
+
+
+def indicator_metric_series(indicators: dict, metric: str, err_type: str):
+    """Extract per-algorithm series for a given indicator metric.
+
+    Parameters
+    ----------
+    indicators : dict
+        The ``indicators`` section returned by :func:`run_experiment`.
+    metric : str
+        Indicator metric name (e.g. ``"HV"`` or ``"IGD"``).
+    err_type : str
+        Error type to extract (``"tp"`` or ``"res"``).
+
+    Returns
+    -------
+    times : list[int]
+        List of time indices.
+    series : list[list[float]]
+        Metric values for each algorithm.
+    labels : list[str]
+        Algorithm names corresponding to ``series`` order.
+    """
+
+    labels = sorted(indicators.keys())
+    series = [indicators[a][err_type][metric] for a in labels]
+    times = list(range(len(series[0]) if series else 0))
+    return times, series, labels
+
+
+def plot_indicator_metric(indicators: dict, metric: str, err_type: str,
+                          title: str, ylabel: str, caption: str | None = None):
+    """Plot an indicator metric over time for each algorithm.
+
+    This is a convenience wrapper around :func:`plot_metric_over_time` that
+    extracts the per-algorithm series for ``metric`` and ``err_type``.
+
+    Parameters
+    ----------
+    indicators : dict
+        The ``indicators`` section returned by :func:`run_experiment`.
+    metric : str
+        Indicator metric name (e.g. ``"HV"``).
+    err_type : str
+        Error type to extract (``"tp"`` or ``"res"``).
+    title : str
+        Title for the plot.
+    ylabel : str
+        Label for the y-axis.
+    caption : str, optional
+        Additional caption displayed below the plot.
+    """
+
+    times, series, labels = indicator_metric_series(indicators, metric, err_type)
+    plot_metric_over_time(times, series, labels, title, ylabel, caption)

--- a/tests/test_plot_indicator_metric.py
+++ b/tests/test_plot_indicator_metric.py
@@ -1,0 +1,19 @@
+import matplotlib
+matplotlib.use("Agg")
+
+from multiobjective.plotting import indicator_metric_series, plot_indicator_metric
+
+
+def test_indicator_series_and_plot():
+    indicators = {
+        "alg1": {"tp": {"HV": [0.1, 0.2]}},
+        "alg2": {"tp": {"HV": [0.3, 0.4]}},
+    }
+
+    times, series, labels = indicator_metric_series(indicators, "HV", "tp")
+    assert times == [0, 1]
+    assert series == [[0.1, 0.2], [0.3, 0.4]]
+    assert labels == ["alg1", "alg2"]
+
+    # Should plot without raising an error
+    plot_indicator_metric(indicators, "HV", "tp", "HV", "HV")


### PR DESCRIPTION
## Summary
- add `indicator_metric_series` to convert experiment indicators to per-algorithm data
- add `plot_indicator_metric` convenience plotting wrapper
- document indicator plotting and update example script
- test indicator series extraction and plotting

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a7ae90ba888324a607fafbfd153027