### PR TITLE
docs: add indicator plotting instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,3 +64,31 @@ plot_tradeoff(
     algs, "Final error–cost tradeoff")
 PY
 ```
+
+### Plotting indicator metrics
+
+The experiment also logs common quality indicators such as hypervolume (HV),
+inverted generational distance (IGD) and additive epsilon (EPS) for each
+algorithm over time. The helper function `indicator_series` from
+`multiobjective.plotting` extracts these values in a convenient form for
+visualisation with `plot_metric_over_time`.
+
+```bash
+python - <<'PY'
+import json
+from multiobjective.plotting import indicator_series, plot_metric_over_time
+
+with open("results.json") as f:
+    results = json.load(f)
+
+# Collect HV values for topology error across all algorithms
+inds = results["indicators"]
+times, hv_series, algs = indicator_series(inds, "HV", err_type="tp")
+
+plot_metric_over_time(times, hv_series, algs,
+                      "Hypervolume over time", "HV")
+PY
+```
+
+The resulting plot shows how the hypervolume indicator evolves for each
+algorithm, enabling direct comparison of their performance.

--- a/multiobjective/plotting.py
+++ b/multiobjective/plotting.py
@@ -2,6 +2,36 @@ import matplotlib.pyplot as plt
 import numpy as np
 
 
+def indicator_series(indicators: dict, name: str, err_type: str = "tp"):
+    """Extract per-algorithm indicator values over time.
+
+    Parameters
+    ----------
+    indicators : mapping
+        The ``"indicators"`` portion of :func:`multiobjective.experiment.run_experiment`
+        output. It maps algorithm names to indicator time series.
+    name : str
+        Indicator name such as ``"HV"`` (hypervolume), ``"IGD"`` or ``"EPS"``.
+    err_type : str, optional
+        Error category to select (``"tp"`` for topology or ``"res"`` for
+        resilience errors).
+
+    Returns
+    -------
+    times : range
+        Time steps corresponding to the indicator values.
+    series : list[list[float]]
+        A list of indicator series, one per algorithm.
+    labels : list[str]
+        Algorithm labels matching ``series`` order.
+    """
+
+    labels = list(indicators)
+    series = [indicators[a][err_type][name] for a in labels]
+    times = range(len(series[0]) if series else 0)
+    return times, series, labels
+
+
 def plot_metric_over_time(times, series, labels, title, ylabel, caption: str | None = None):
     plt.figure(figsize=(10,4))
     for ys, lab in zip(series, labels):


### PR DESCRIPTION
## Summary
- add `indicator_series` helper to gather indicator values over time
- document how to extract and plot indicator metrics such as hypervolume

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a7ae9223908324b2106d8375e23cb9