### PR TITLE
Add per-algorithm SCS metrics and plotting helper

### DIFF
--- a/examples/plot_results.py
+++ b/examples/plot_results.py
@@ -27,6 +27,7 @@ from multiobjective.plotting import (
     plot_metric_with_std,
     plot_tradeoff,
     plot_indicator_metric,
+    plot_scs_over_time,
 )
 from multiobjective.simulation import euclidean_distance
 from multiobjective.metrics.scs import blended_error
@@ -142,29 +143,26 @@ def main() -> None:
         "Hypervolume",
     )
 
-    # Plot actual vs expected SCS for topology and resilience errors
-    scs_tp = results["scs"]["tp"]
-    scs_E_tp = results["scs"]["E_tp"]
-    scs_res = results["scs"]["res"]
-    scs_E_res = results["scs"]["E_res"]
+    # Plot SCS trajectories for topology and resilience errors
+    tp_scs_series = []
+    tp_labels = []
+    for alg in algs:
+        tp_scs_series.extend([
+            series[alg]["scs"]["tp"]["actual"],
+            series[alg]["scs"]["tp"]["expected"],
+        ])
+        tp_labels.extend([f"{alg} actual", f"{alg} expected"])
+    plot_scs_over_time(times, tp_scs_series, tp_labels, "Topology continuity over time")
 
-    plot_metric_over_time(
-        times,
-        [scs_tp, scs_E_tp],
-        ["Actual SCS", "Expected SCS"],
-        "Topology continuity over time",
-        "Continuity score",
-        caption="Overlay of actual vs expected service continuity for topology errors",
-    )
-
-    plot_metric_over_time(
-        times,
-        [scs_res, scs_E_res],
-        ["Actual SCS", "Expected SCS"],
-        "Resilience continuity over time",
-        "Continuity score",
-        caption="Overlay of actual vs expected service continuity for resilience errors",
-    )
+    res_scs_series = []
+    res_labels = []
+    for alg in algs:
+        res_scs_series.extend([
+            series[alg]["scs"]["res"]["actual"],
+            series[alg]["scs"]["res"]["expected"],
+        ])
+        res_labels.extend([f"{alg} actual", f"{alg} expected"])
+    plot_scs_over_time(times, res_scs_series, res_labels, "Resilience continuity over time")
 
     # Show error–cost tradeoffs for the final time step
     final_errors = [errs[-1] for errs in error_series]

--- a/multiobjective/plotting.py
+++ b/multiobjective/plotting.py
@@ -45,6 +45,29 @@ def plot_metric_over_time(times, series, labels, title, ylabel, caption: str | N
         plt.figtext(0.5, -0.05, caption, ha="center", va="center", fontsize=9)
     plt.show()
 
+
+def plot_scs_over_time(times, series, labels, title, caption: str | None = None):
+    """Plot service-continuity scores over time.
+
+    This is a thin wrapper around :func:`plot_metric_over_time` with the
+    y-axis label preset to ``"SCS"``.
+
+    Parameters
+    ----------
+    times : sequence
+        X-axis values (time steps).
+    series : sequence of sequences
+        SCS values for each labelled series.
+    labels : sequence of str
+        Labels corresponding to ``series``.
+    title : str
+        Title for the plot.
+    caption : str, optional
+        Caption placed below the plot.
+    """
+
+    plot_metric_over_time(times, series, labels, title, ylabel="SCS", caption=caption)
+
 def plot_metric_with_std(times, series, stds, labels, title, ylabel):
     """Plot metric trajectories with mean and standard deviation.
 

--- a/tests/test_experiment.py
+++ b/tests/test_experiment.py
@@ -29,8 +29,11 @@ def test_run_experiment_minimal(monkeypatch):
 
     result = experiment.run_experiment(cfg)
 
-    assert {"series", "indicators", "scs", "meta"} <= set(result.keys())
+    assert {"series", "indicators", "meta"} <= set(result.keys())
     assert "greedy" in result["series"]
+    scs_section = result["series"]["greedy"].get("scs")
+    assert scs_section is not None and set(scs_section.keys()) == {"tp", "res"}
+    assert len(scs_section["tp"]["actual"]) == cfg.num_times
 
 
 def test_run_experiment_no_feasible_pairs():


### PR DESCRIPTION
## Summary
- track SCS and expected SCS per algorithm and error type
- expose SCS metrics and add plotting helper for continuity trajectories
- update example script and tests for new SCS structure

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a7e9ed2d6483249cfe2992a4651caa