### PR TITLE
Add SCS vs cost quantile plotting helper

### DIFF
--- a/multiobjective/plotting.py
+++ b/multiobjective/plotting.py
@@ -193,3 +193,42 @@ def plot_pareto_front_shift(front_w0, front_w1, alg_label):
     plt.title(alg_label)
     plt.grid(True)
     plt.legend()
+
+
+def plot_scs_vs_cost_at_error(costs_w, scs_w, labels, title):
+    """Plot SCS against cost for two SCS weights at a fixed error level.
+
+    Parameters
+    ----------
+    costs_w : mapping
+        Dictionary mapping SCS weights to cost values for each algorithm.
+    scs_w : mapping
+        Dictionary mapping SCS weights to service-continuity scores for each
+        algorithm.
+    labels : sequence of str
+        Labels for the algorithms.
+    title : str
+        Title for the plot.
+    """
+
+    weights = sorted(costs_w)
+    markers = {weights[0]: "o", weights[1]: "s"}
+    colours = [f"C{i}" for i in range(len(labels))]
+
+    for i, lab in enumerate(labels):
+        xs = [costs_w[w][i] for w in weights]
+        ys = [scs_w[w][i] for w in weights]
+        plt.plot(xs, ys, linestyle="--", color=colours[i], label=lab)
+        for w in weights:
+            plt.scatter(costs_w[w][i], scs_w[w][i],
+                        color=colours[i], marker=markers[w])
+
+    # Legend entries for weight markers
+    for w in weights:
+        plt.scatter([], [], color="k", marker=markers[w], label=f"w={w}")
+
+    plt.xlabel("Cost")
+    plt.ylabel("SCS")
+    plt.title(title)
+    plt.grid(True)
+    plt.legend()


### PR DESCRIPTION
## Summary
- add `plot_scs_vs_cost_at_error` helper to compare SCS and cost across SCS weights
- extend `plot_results` example to compute error quantile slices and visualise cost/SCS trade-offs for w=0 vs w=0.4

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a802d10b6883248a5f4333ef01316f