### PR TITLE
Add churn metric and plotting utilities

### DIFF
--- a/examples/plot_churn.py
+++ b/examples/plot_churn.py
@@ -1,0 +1,50 @@
+"""Example script to visualise churn trends for different SCS weights."""
+import matplotlib
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+
+from pathlib import Path
+import sys
+from dataclasses import replace
+
+# Ensure repository root is on path for local execution
+_script_dir = Path(__file__).resolve().parent
+_repo_root = _script_dir.parent
+if str(_repo_root) not in sys.path:
+    sys.path.append(str(_repo_root))
+
+import numpy as np
+from multiobjective.config import Config
+from multiobjective.experiment import run_experiment
+from multiobjective.plotting import plot_churn_over_time
+from multiobjective.metrics import compute_churn
+from multiobjective import algorithms
+from multiobjective.algorithms.greedy import greedy_run
+
+
+def main() -> None:
+    """Run minimal experiments and plot churn for two SCS weights."""
+    algorithms.ALG_REGISTRY = {"greedy": greedy_run}
+
+    cfg = Config(num_times=5, num_services=8)
+    results_w0 = run_experiment(cfg)
+    results_w04 = run_experiment(replace(cfg, scs_lookahead_weight=0.4))
+
+    times = list(range(1, cfg.num_times))
+    alg = "greedy"
+    churn_w0 = compute_churn(results_w0["series"][alg]["assignments"]["tp"])
+    churn_w04 = compute_churn(results_w04["series"][alg]["assignments"]["tp"])
+    scs_w0 = results_w0["series"][alg]["scs"]["tp"]["actual"][1:]
+    scs_w04 = results_w04["series"][alg]["scs"]["tp"]["actual"][1:]
+
+    plot_churn_over_time(
+        times,
+        [churn_w0, churn_w04],
+        [scs_w0, scs_w04],
+        ["w=0", "w=0.4"],
+        f"{alg} churn over time",
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/multiobjective/experiment.py
+++ b/multiobjective/experiment.py
@@ -90,6 +90,7 @@ def run_experiment(cfg: Config) -> dict:
             # SCS metrics per algorithm/error-type
             prev_assign = None
             actual, expected = [], []
+            assigns: list[list[int]] = []
             for t in range(cfg.num_times):
                 prods, cons = records[t]
                 assign = []
@@ -106,11 +107,13 @@ def run_experiment(cfg: Config) -> dict:
                 )
                 actual.append(score)
                 expected.append(mean_next)
+                assigns.append(assign)
                 prev_assign = assign[:]
             series.setdefault("scs", {})[te] = {
                 "actual": actual,
                 "expected": expected,
             }
+            series.setdefault("assignments", {})[te] = assigns
 
         outputs[alg_name] = series
 

--- a/multiobjective/metrics/__init__.py
+++ b/multiobjective/metrics/__init__.py
@@ -1,4 +1,5 @@
 from .scs import SCSConfig, SCSComponents, scs, expected_scs_next
+from .churn import compute_churn
 
 # Re-export the primary SCS utilities for convenient external use.
 __all__ = (
@@ -6,4 +7,5 @@ __all__ = (
     "SCSComponents",
     "scs",
     "expected_scs_next",
+    "compute_churn",
 )

--- a/multiobjective/metrics/churn.py
+++ b/multiobjective/metrics/churn.py
@@ -1,0 +1,26 @@
+from collections.abc import Sequence
+
+
+def compute_churn(assignments: Sequence[Sequence[int]]) -> list[float]:
+    """Compute consumer-provider churn between consecutive time steps.
+
+    Parameters
+    ----------
+    assignments : sequence of sequences of int
+        ``assignments[t][i]`` denotes the provider index serving consumer ``i``
+        at time ``t``.
+
+    Returns
+    -------
+    list of float
+        Fraction of consumers whose provider changes between ``t`` and
+        ``t+1`` for each consecutive pair of assignments.
+    """
+    churn: list[float] = []
+    for prev, curr in zip(assignments[:-1], assignments[1:]):
+        if not prev:
+            churn.append(0.0)
+            continue
+        changes = sum(1 for a, b in zip(prev, curr) if a != b)
+        churn.append(changes / len(prev))
+    return churn

--- a/multiobjective/plotting.py
+++ b/multiobjective/plotting.py
@@ -68,6 +68,46 @@ def plot_scs_over_time(times, series, labels, title, caption: str | None = None)
 
     plot_metric_over_time(times, series, labels, title, ylabel="SCS", caption=caption)
 
+
+def plot_churn_over_time(times, churn_series, scs_series, labels, title):
+    """Plot churn fractions over time, optionally overlaying SCS values.
+
+    Parameters
+    ----------
+    times : sequence
+        X-axis values corresponding to ``churn_series``.
+    churn_series : sequence of sequences
+        Churn fractions for each labelled series.
+    scs_series : sequence of sequences or ``None``
+        Mean service-continuity scores aligned with ``times``.  If provided,
+        they are plotted on a secondary y-axis.
+    labels : sequence of str
+        Labels for each series.
+    title : str
+        Title for the plot.
+    """
+
+    fig, ax1 = plt.subplots(figsize=(10, 4))
+    for ys, lab in zip(churn_series, labels):
+        ax1.plot(times, ys, marker="o", label=f"{lab} churn")
+    ax1.set_xlabel("t")
+    ax1.set_ylabel("Churn")
+    ax1.grid(True)
+
+    if scs_series:
+        ax2 = ax1.twinx()
+        for ys, lab in zip(scs_series, labels):
+            ax2.plot(times, ys, linestyle="--", marker="x", label=f"{lab} SCS")
+        ax2.set_ylabel("SCS")
+        lines1, labels1 = ax1.get_legend_handles_labels()
+        lines2, labels2 = ax2.get_legend_handles_labels()
+        ax1.legend(lines1 + lines2, labels1 + labels2)
+    else:
+        ax1.legend()
+
+    ax1.set_title(title)
+    plt.show()
+
 def plot_metric_with_std(times, series, stds, labels, title, ylabel):
     """Plot metric trajectories with mean and standard deviation.
 

--- a/tests/metrics/test_churn.py
+++ b/tests/metrics/test_churn.py
@@ -1,0 +1,11 @@
+from multiobjective.metrics import compute_churn
+
+
+def test_compute_churn_simple():
+    assignments = [[0, 1, 1], [1, 1, 0], [1, 0, 0]]
+    churn = compute_churn(assignments)
+    assert churn == [2/3, 1/3]
+
+
+def test_compute_churn_single_step():
+    assert compute_churn([[0, 1]]) == []

--- a/tests/test_experiment.py
+++ b/tests/test_experiment.py
@@ -34,6 +34,9 @@ def test_run_experiment_minimal(monkeypatch):
     scs_section = result["series"]["greedy"].get("scs")
     assert scs_section is not None and set(scs_section.keys()) == {"tp", "res"}
     assert len(scs_section["tp"]["actual"]) == cfg.num_times
+    assignments = result["series"]["greedy"]["assignments"]["tp"]
+    assert len(assignments) == cfg.num_times
+    assert len(assignments[0]) == result["meta"]["num_consumers"]
 
 
 def test_run_experiment_no_feasible_pairs():

--- a/tests/test_plot_churn.py
+++ b/tests/test_plot_churn.py
@@ -1,0 +1,11 @@
+import matplotlib
+matplotlib.use("Agg")
+
+from multiobjective.plotting import plot_churn_over_time
+
+
+def test_plot_churn_over_time_runs():
+    times = [1, 2, 3]
+    churn = [[0.2, 0.3, 0.1]]
+    scs = [[0.9, 0.85, 0.8]]
+    plot_churn_over_time(times, churn, scs, ["alg"], "churn")


### PR DESCRIPTION
## Summary
- Record per-time provider assignments during experiments
- Introduce `compute_churn` to measure provider switching
- Add `plot_churn_over_time` and example script demonstrating churn trends

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a80443c5d48324b9869d3e44df0103