### PR TITLE
Add runtime logging and quality-time plotting

### DIFF
--- a/multiobjective/algorithms/greedy.py
+++ b/multiobjective/algorithms/greedy.py
@@ -1,5 +1,6 @@
 from typing import Tuple, List
 import numpy as np
+import time
 from ..types import ErrorType, ProviderRecord, ConsumerRecord
 from ..config import Config, coverage_radius
 from ..rng import RNGPool
@@ -16,8 +17,9 @@ def greedy_run(cfg: Config, rng_pool: RNGPool, records: dict, cost_per: dict,
                err_type: ErrorType, metrics: MetricsRecorder,
                streaks: StreakTracker, norm_fn,
                transition_matrix: dict | None = None):
-    errors, costs, stds = [], [], []
+    errors, costs, stds, times = [], [], [], []
     radius = coverage_radius(cfg)
+    start = time.perf_counter()
     for t in range(cfg.num_times):
         scs_rng = rng_pool.for_time("scs", t)
 
@@ -68,4 +70,5 @@ def greedy_run(cfg: Config, rng_pool: RNGPool, records: dict, cost_per: dict,
         std_err = float(np.std([m[0] for m in matched])) if len(matched)>1 else 0.0
         errors.append(avg_err); costs.append(avg_cost); stds.append(std_err)
         metrics.record("greedy", err_type, t, [(avg_err, avg_cost)])
-    return errors, costs, stds
+        times.append(time.perf_counter() - start)
+    return errors, costs, stds, times

--- a/multiobjective/algorithms/mogwo.py
+++ b/multiobjective/algorithms/mogwo.py
@@ -1,6 +1,7 @@
 import numpy as np
 from ..config import Config
 from ..rng import RNGPool
+import time
 from ..types import ErrorType, ProviderRecord, ConsumerRecord
 from ..indicators import MetricsRecorder
 from ..pareto import crowding_distance
@@ -39,7 +40,8 @@ def _fast_nds(objs):
 def run_mogwo(cfg: Config, rng_pool: RNGPool, records: dict, cost_per: dict,
               err_type: ErrorType, metrics: MetricsRecorder, norm_fn,
               transition_matrix: dict | None = None):
-    errors, costs, stds = [], [], []
+    errors, costs, stds, times = [], [], [], []
+    start = time.perf_counter()
     for t in range(cfg.num_times):
         rng = rng_pool.for_("gwo", t)
         scs_rng = rng_pool.for_("scs", t)
@@ -114,4 +116,5 @@ def run_mogwo(cfg: Config, rng_pool: RNGPool, records: dict, cost_per: dict,
         else:
             metrics.record("mogwo", err_type, t, [])
             errors.append(0.0); costs.append(0.0); stds.append(0.0)
-    return errors, costs, stds
+        times.append(time.perf_counter() - start)
+    return errors, costs, stds, times

--- a/multiobjective/algorithms/mopso.py
+++ b/multiobjective/algorithms/mopso.py
@@ -1,4 +1,4 @@
-import numpy as np
+import numpy as np, time
 from ..config import Config
 from ..rng import RNGPool
 from ..types import ErrorType, ProviderRecord, ConsumerRecord
@@ -39,7 +39,8 @@ def _fast_nds(objs):
 def run_mopso(cfg: Config, rng_pool: RNGPool, records: dict, cost_per: dict,
               err_type: ErrorType, metrics: MetricsRecorder, norm_fn,
               transition_matrix: dict | None = None):
-    errors, costs, stds = [], [], []
+    errors, costs, stds, times = [], [], [], []
+    start = time.perf_counter()
     for t in range(cfg.num_times):
         rng = rng_pool.for_("pso", t)
         scs_rng = rng_pool.for_("scs", t)
@@ -113,4 +114,5 @@ def run_mopso(cfg: Config, rng_pool: RNGPool, records: dict, cost_per: dict,
         else:
             metrics.record("mopso", err_type, t, [])
             errors.append(0.0); costs.append(0.0); stds.append(0.0)
-    return errors, costs, stds
+        times.append(time.perf_counter() - start)
+    return errors, costs, stds, times

--- a/multiobjective/experiment.py
+++ b/multiobjective/experiment.py
@@ -65,7 +65,7 @@ def run_experiment(cfg: Config) -> dict:
         series = {}
         for te in ["tp", "res"]:
             if alg_name == "greedy":
-                errs, costs, stds = fn(
+                errs, costs, stds, times = fn(
                     cfg,
                     rng_pool,
                     records,
@@ -76,7 +76,7 @@ def run_experiment(cfg: Config) -> dict:
                     norm_err,
                 )
             else:
-                errs, costs, stds = fn(
+                errs, costs, stds, times = fn(
                     cfg,
                     rng_pool,
                     records,
@@ -88,6 +88,7 @@ def run_experiment(cfg: Config) -> dict:
             series.setdefault("errors", {})[te] = errs
             series.setdefault("costs", {})[te] = costs
             series.setdefault("stds", {})[te] = stds
+            series.setdefault("times", {})[te] = times
 
             # SCS metrics per algorithm/error-type
             prev_assign = None

--- a/multiobjective/plotting.py
+++ b/multiobjective/plotting.py
@@ -155,6 +155,39 @@ def plot_metric_with_std(times, series, stds, labels, title, ylabel):
     plt.legend()
     plt.show()
 
+
+def plot_quality_vs_time(times, hv_series, time_series, alg_labels):
+    """Plot hypervolume quality against cumulative runtime.
+
+    Parameters
+    ----------
+    times : sequence
+        Time step indices (unused but kept for API symmetry).
+    hv_series : sequence of sequences
+        For each algorithm, a list of hypervolume series, one per seed.
+    time_series : sequence of sequences
+        For each algorithm, a list of runtime series matching ``hv_series``.
+    alg_labels : sequence of str
+        Labels for each algorithm.
+    """
+
+    plt.figure(figsize=(10, 4))
+    for hv_runs, t_runs, lab in zip(hv_series, time_series, alg_labels):
+        hv_arr = np.array(hv_runs)
+        t_arr = np.array(t_runs)
+        median_hv = np.median(hv_arr, axis=0)
+        q1 = np.percentile(hv_arr, 25, axis=0)
+        q3 = np.percentile(hv_arr, 75, axis=0)
+        median_t = np.median(t_arr, axis=0)
+        plt.plot(median_t, median_hv, label=lab)
+        plt.fill_between(median_t, q1, q3, alpha=0.3)
+    plt.xlabel("time (s)")
+    plt.ylabel("HV")
+    plt.title("Quality vs Time")
+    plt.grid(True)
+    plt.legend()
+    plt.show()
+
 def plot_tradeoff(errors, costs, labels, title):
     plt.figure(figsize=(8,6))
     mk = ["o","s","^","x","d","*"]

--- a/tests/test_experiment.py
+++ b/tests/test_experiment.py
@@ -38,6 +38,11 @@ def test_run_experiment_minimal(monkeypatch):
     assert len(assignments) == cfg.num_times
     assert len(assignments[0]) == result["meta"]["num_consumers"]
 
+    times_section = result["series"]["greedy"].get("times")
+    assert times_section is not None and set(times_section.keys()) == {"tp", "res"}
+    assert len(times_section["tp"]) == cfg.num_times
+    assert all(t2 >= t1 for t1, t2 in zip(times_section["tp"], times_section["tp"][1:]))
+
 
 def test_run_experiment_no_feasible_pairs():
     cfg = Config(

--- a/tests/test_plot_quality_vs_time.py
+++ b/tests/test_plot_quality_vs_time.py
@@ -1,0 +1,11 @@
+import matplotlib
+matplotlib.use("Agg")
+
+from multiobjective.plotting import plot_quality_vs_time
+
+
+def test_plot_quality_vs_time_runs():
+    times = [0, 1]
+    hv_series = [[[0.1, 0.2], [0.15, 0.25]]]
+    time_series = [[[0.01, 0.03], [0.02, 0.04]]]
+    plot_quality_vs_time(times, hv_series, time_series, ["alg"])  # Should not raise


### PR DESCRIPTION
## Summary
- record per-time-step cumulative runtime for all algorithms
- expose runtime series in `run_experiment`
- add `plot_quality_vs_time` to visualize hypervolume against runtime
- cover new runtime data and plotting helper with tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a8b70a48b0832493a054a0b818d687