### PR TITLE
Add assignment heatmap plot and example

### DIFF
--- a/examples/plot_assignments.py
+++ b/examples/plot_assignments.py
@@ -1,0 +1,49 @@
+"""Example script to visualise assignment heatmaps for two SCS weights."""
+
+import matplotlib
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+
+from pathlib import Path
+import sys
+from dataclasses import replace
+
+# Ensure repository root is on path for local execution
+_script_dir = Path(__file__).resolve().parent
+_repo_root = _script_dir.parent
+if str(_repo_root) not in sys.path:
+    sys.path.append(str(_repo_root))
+
+from multiobjective.config import Config
+from multiobjective.experiment import run_experiment
+from multiobjective.plotting import plot_assignment_heatmap
+from multiobjective import algorithms
+from multiobjective.algorithms.greedy import greedy_run
+
+
+def main() -> None:
+    """Run minimal experiments and plot assignments for two SCS weights."""
+
+    algorithms.ALG_REGISTRY = {"greedy": greedy_run}
+
+    cfg = Config(num_times=5, num_services=8)
+    results_w0 = run_experiment(cfg)
+    results_w04 = run_experiment(replace(cfg, scs_lookahead_weight=0.4))
+
+    alg = "greedy"
+    assigns_w0 = results_w0["series"][alg]["assignments"]["tp"]
+    assigns_w04 = results_w04["series"][alg]["assignments"]["tp"]
+
+    fig, axes = plt.subplots(1, 2, figsize=(8, 4))
+    plt.sca(axes[0])
+    plot_assignment_heatmap(assigns_w0, "w=0")
+    plt.sca(axes[1])
+    plot_assignment_heatmap(assigns_w04, "w=0.4")
+    fig.suptitle("Assignment heatmaps")
+    fig.tight_layout()
+    plt.show()
+
+
+if __name__ == "__main__":
+    main()
+

--- a/multiobjective/plotting.py
+++ b/multiobjective/plotting.py
@@ -350,3 +350,26 @@ def plot_scs_vs_weight_at_error(scs_w, weights, labels, title):
     plt.title(title)
     plt.grid(True)
     plt.legend()
+
+
+def plot_assignment_heatmap(assign_matrix, title):
+    """Visualise provider assignments over time as a heatmap.
+
+    Parameters
+    ----------
+    assign_matrix : sequence of sequences of int
+        Assignment matrix where ``assign_matrix[t][i]`` is the provider index
+        serving consumer ``i`` at time step ``t``.
+    title : str
+        Title for the heatmap.
+    """
+
+    arr = np.asarray(assign_matrix).T
+    cmap = plt.get_cmap("tab20", int(arr.max()) + 1)
+    ax = plt.gca()
+    im = ax.imshow(arr, cmap=cmap, aspect="auto", interpolation="nearest")
+    ax.set_xlabel("t")
+    ax.set_ylabel("consumer")
+    ax.set_title(title)
+    cbar = plt.colorbar(im, ax=ax, ticks=range(int(arr.max()) + 1))
+    cbar.set_label("provider")

--- a/tests/test_plot_assignments.py
+++ b/tests/test_plot_assignments.py
@@ -1,0 +1,10 @@
+import matplotlib
+matplotlib.use("Agg")
+
+from multiobjective.plotting import plot_assignment_heatmap
+
+
+def test_plot_assignment_heatmap_runs():
+    assignments = [[0, 1], [1, 0], [0, 1]]
+    plot_assignment_heatmap(assignments, "assignments")
+


### PR DESCRIPTION
## Summary
- Implement `plot_assignment_heatmap` to visualise consumer-provider assignments
- Provide example script generating side-by-side assignment heatmaps for two SCS weights
- Add test covering the new plotting helper

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a8ba7a2380832482e452ddc0694fe6