### PR TITLE
Plot full error–cost trajectories

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,8 @@ python examples/plot_results.py
 ```
 
 The script runs `run_experiment` with a tiny configuration and displays error
-and cost trends for two algorithms alongside their final error–cost tradeoff.
+and cost trends for two algorithms alongside their error–cost tradeoff across
+time.
 
 ### Plotting CLI results
 
@@ -66,11 +67,11 @@ plot_indicator_metric(
     "Hypervolume",
 )
 
-# Plot final trade-off
+# Plot trade-off over time
 plot_tradeoff(
-    [series[a]["errors"]["tp"][-1] for a in algs],
-    [series[a]["costs"]["tp"][-1] for a in algs],
-    algs, "Final error–cost tradeoff")
+    [series[a]["errors"]["tp"] for a in algs],
+    [series[a]["costs"]["tp"] for a in algs],
+    algs, "Error–cost tradeoff over time")
 PY
 ```
 

--- a/examples/plot_results.py
+++ b/examples/plot_results.py
@@ -174,14 +174,15 @@ def main() -> None:
         res_labels.extend([f"{alg} actual", f"{alg} expected"])
     plot_scs_over_time(times, res_scs_series, res_labels, "Resilience continuity over time")
 
-    # Show error–cost tradeoffs for the final time step
-    final_errors = [errs[-1] for errs in error_series]
-    final_costs = [cs[-1] for cs in cost_series]
-    plot_tradeoff(final_errors, final_costs, algs, "Error–Cost tradeoff at final step")
+    # Show error–cost tradeoffs across all time steps
+    plot_tradeoff(error_series, cost_series, algs, "Error–Cost tradeoff over time")
 
-    res_final_errors = [errs[-1] for errs in res_error_series]
-    res_final_costs = [cs[-1] for cs in res_cost_series]
-    plot_tradeoff(res_final_errors, res_final_costs, algs, "Resource error–cost tradeoff at final step")
+    plot_tradeoff(
+        res_error_series,
+        res_cost_series,
+        algs,
+        "Resource error–cost tradeoff over time",
+    )
 
     # Compare cost and SCS at selected error quantiles for different weights
     quantiles = [0.25, 0.50, 0.75]

--- a/multiobjective/plotting.py
+++ b/multiobjective/plotting.py
@@ -213,11 +213,39 @@ def plot_quality_vs_time(times, hv_series, time_series, alg_labels):
     plt.show()
 
 def plot_tradeoff(errors, costs, labels, title):
-    plt.figure(figsize=(8,6))
-    mk = ["o","s","^","x","d","*"]
-    for i, (e,c,l) in enumerate(zip(errors, costs, labels)):
-        plt.scatter(e, c, marker=mk[i%len(mk)], label=l)
-    plt.xlabel("Error"); plt.ylabel("Cost"); plt.title(title); plt.grid(True); plt.legend(); plt.show()
+    """Scatter error–cost pairs for algorithms over time.
+
+    Parameters
+    ----------
+    errors : sequence of sequences
+        ``errors[i][t]`` gives the error value for algorithm ``i`` at time ``t``.
+    costs : sequence of sequences
+        ``costs[i][t]`` gives the cost value for algorithm ``i`` at time ``t``.
+    labels : sequence of str
+        Labels corresponding to each algorithm.
+    title : str
+        Title for the plot.
+    """
+
+    plt.figure(figsize=(8, 6))
+    markers = ["o", "s", "^", "x", "d", "*"]
+    colours = [f"C{i}" for i in range(len(labels))]
+
+    for i, (err_series, cost_series, lab) in enumerate(zip(errors, costs, labels)):
+        marker = markers[i % len(markers)]
+        colour = colours[i % len(colours)]
+        last_idx = len(err_series) - 1
+        for t, (e, c) in enumerate(zip(err_series, cost_series)):
+            alpha = 1.0 if t == last_idx else 0.3
+            lbl = lab if t == last_idx else None
+            plt.scatter(e, c, marker=marker, color=colour, alpha=alpha, label=lbl)
+
+    plt.xlabel("Error")
+    plt.ylabel("Cost")
+    plt.title(title)
+    plt.grid(True)
+    plt.legend()
+    plt.show()
 
 
 def indicator_metric_series(indicators: dict, metric: str, err_type: str):


### PR DESCRIPTION
## Summary
- Plot error–cost tradeoffs using complete time-series for each algorithm
- Scatter intermediate points with reduced alpha to show progression over time
- Update example script and README usage accordingly

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68acbe9fd5bc8324a3073e60cc70a323