### PR TITLE
Fix SCS logging to record algorithm assignments

### DIFF
--- a/multiobjective/algorithms/greedy.py
+++ b/multiobjective/algorithms/greedy.py
@@ -1,33 +1,49 @@
-from typing import Tuple, List
 import numpy as np
 import time
-from ..types import ErrorType, ProviderRecord, ConsumerRecord
+from ..types import ErrorType
 from ..config import Config, coverage_radius
 from ..rng import RNGPool
 from ..simulation import euclidean_distance
-from ..qos import reg_err
 from ..streaks import StreakTracker
 from ..indicators import MetricsRecorder
 from ..defaults import OU_PARAMS_DEFAULT
 # and, if you need the helper:
+from ..metrics import scs as compute_scs, expected_scs_next
 from ..metrics.scs import blended_error
 
 
-def greedy_run(cfg: Config, rng_pool: RNGPool, records: dict, cost_per: dict,
-               err_type: ErrorType, metrics: MetricsRecorder,
-               streaks: StreakTracker, norm_fn,
-               transition_matrix: dict | None = None):
+def greedy_run(
+    cfg: Config,
+    rng_pool: RNGPool,
+    records: dict,
+    cost_per: dict,
+    err_type: ErrorType,
+    metrics: MetricsRecorder,
+    streaks: StreakTracker,
+    norm_fn,
+    transition_matrix: dict | None = None,
+):
     errors, costs, stds, times = [], [], [], []
+    assignments: list[list[int]] = []
+    scs_actual: list[float] = []
+    scs_expected: list[float] = []
+
     radius = coverage_radius(cfg)
     start = time.perf_counter()
+    prev_assign: list[int] | None = None
+    scs_cfg = cfg.scs
+
     for t in range(cfg.num_times):
         scs_rng = rng_pool.for_time("scs", t)
 
         prods, cons = records[t]
         curr_max, curr_min = max(cost_per[f"{t}"]), min(cost_per[f"{t}"])
-        def cost_norm(x): return (x - curr_min) / (curr_max - curr_min + 1e-12)
+
+        def cost_norm(x):
+            return (x - curr_min) / (curr_max - curr_min + 1e-12)
 
         matched = []
+        assign: list[int] = []
         for c in cons:
             scores, idxs = [], []
             for i, p in enumerate(prods):
@@ -35,10 +51,15 @@ def greedy_run(cfg: Config, rng_pool: RNGPool, records: dict, cost_per: dict,
                     continue
                 r = p.qos_prob
                 v = p.qos_volatility
-            
-                
+
                 err_for_score = blended_error(
-                    err_type, p, c, t, cfg, norm_fn, scs_rng,
+                    err_type,
+                    p,
+                    c,
+                    t,
+                    cfg,
+                    norm_fn,
+                    scs_rng,
                     ou_params=OU_PARAMS_DEFAULT,
                     transition_matrix=transition_matrix,
                 )
@@ -49,26 +70,58 @@ def greedy_run(cfg: Config, rng_pool: RNGPool, records: dict, cost_per: dict,
                     / (max(r, 1e-6) ** cfg.gamma_qos)
                 )
 
-                scores.append(score); idxs.append(i)
+                scores.append(score)
+                idxs.append(i)
             if not idxs:
                 raise RuntimeError(
                     f"No providers within coverage for c={c.service_id} at t={t}"
                 )
             best_i = idxs[int(np.argmin(scores))]
             p = prods[best_i]
+            assign.append(best_i)
+
             # streak continuity bookkeeping
             streaks.update(t, c.service_id, p.service_id)
             e = blended_error(
-                err_type, p, c, t, cfg, norm_fn, scs_rng,
+                err_type,
+                p,
+                c,
+                t,
+                cfg,
+                norm_fn,
+                scs_rng,
                 ou_params=OU_PARAMS_DEFAULT,
                 transition_matrix=transition_matrix,
             )
 
             matched.append((e, cost_norm(p.cost)))
 
-        avg_err = float(np.mean([m[0] for m in matched])); avg_cost=float(np.mean([m[1] for m in matched]))
-        std_err = float(np.std([m[0] for m in matched])) if len(matched)>1 else 0.0
-        errors.append(avg_err); costs.append(avg_cost); stds.append(std_err)
+        avg_err = float(np.mean([m[0] for m in matched]))
+        avg_cost = float(np.mean([m[1] for m in matched]))
+        std_err = float(np.std([m[0] for m in matched])) if len(matched) > 1 else 0.0
+        errors.append(avg_err)
+        costs.append(avg_cost)
+        stds.append(std_err)
         metrics.record("greedy", err_type, t, [(avg_err, avg_cost)])
         times.append(time.perf_counter() - start)
-    return errors, costs, stds, times
+
+        score, _ = compute_scs(assign, (prods, cons), prev_assign, cfg, scs_cfg)
+        mean_next, _ = expected_scs_next(
+            assign,
+            (prods, cons),
+            prev_assign,
+            cfg,
+            scs_cfg,
+            scs_rng,
+            transition_matrix,
+        )
+        scs_actual.append(score)
+        scs_expected.append(mean_next)
+        assignments.append(assign[:])
+        prev_assign = assign[:]
+
+    return errors, costs, stds, times, {
+        "assignments": assignments,
+        "scs_actual": scs_actual,
+        "scs_expected": scs_expected,
+    }


### PR DESCRIPTION
## Summary
- capture greedy assignment decisions while computing SCS metrics and look-ahead expectations
- teach `run_experiment` to consume algorithm-supplied assignments/SCS data before falling back to reconstruction
- add a regression test proving the experiment pipeline preserves algorithm-provided continuity traces

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ce0f5b184483249cfe19878047c956